### PR TITLE
chore: replace helper `incr_rel` with `u32::saturating_add`

### DIFF
--- a/resharp-algebra/src/lib.rs
+++ b/resharp-algebra/src/lib.rs
@@ -179,15 +179,6 @@ struct MetadataBuilder {
     pub array: Vec<Metadata>,
 }
 
-mod helpers {
-    pub(crate) fn incr_rel(n1: u32) -> u32 {
-        match n1.overflowing_add(1) {
-            (_, true) => u32::MAX,
-            (res, false) => res,
-        }
-    }
-}
-
 impl MetadataBuilder {
     fn new() -> MetadataBuilder {
         Self {
@@ -1425,7 +1416,7 @@ impl RegexBuilder {
 
                 let la = {
                     let this = &mut *self;
-                    let rel = helpers::incr_rel(rel);
+                    let rel = rel.saturating_add(1);
                     this.mk_binary(
                         la_body_der,
                         la_tail_der,
@@ -1440,7 +1431,7 @@ impl RegexBuilder {
                     let look_only = {
                         let this = &mut *self;
                         let right = TRegexId::MISSING;
-                        let rel = helpers::incr_rel(rel);
+                        let rel = rel.saturating_add(1);
                         this.mk_binary(
                             la_body_der,
                             right,


### PR DESCRIPTION
They should be equivalent: see https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=cbfb9f3adf3e9c783f078faa233db9d3

Feel free to ignore; this is a very minor cleanup I noticed while reading through the codebase.

<details><summary>Tests passed on my machine.</summary>

```sh
cargo test
```
```
warning: function `run_is_match_file` is never used
  --> resharp-engine/tests/engine_test.rs:15:4
   |
15 | fn run_is_match_file(filename: &str) {
   |    ^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: `resharp` (test "engine_test") generated 1 warning
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running unittests src/lib.rs (target/debug/deps/resharp-f734a95c2266b1c0)

running 38 tests
test simd::neon::tests::fwd_literal_all_fixed ... ok
test simd::neon::tests::fwd_literal_basic ... ok
test simd::neon::tests::fwd_literal_all_fixed_long ... ok
test simd::neon::tests::fwd_literal_long ... ok
test simd::neon::tests::fwd_prefix_at_chunk_boundaries ... ok
test simd::neon::tests::fwd_prefix_char_class ... ok
test simd::neon::tests::fwd_prefix_finds_first ... ok
test simd::neon::tests::fwd_prefix_no_nibble_collision ... ok
test simd::neon::tests::fwd_literal_size_sweep ... ok
test simd::neon::tests::fwd_prefix_teddy1 ... ok
test simd::neon::tests::fwd_prefix_teddy2 ... ok
test simd::neon::tests::fwd_prefix_teddy3 ... ok
test simd::neon::tests::fwd_prefix_size_sweep ... ok
test simd::neon::tests::fwd_prefix_teddy3_second_chunk ... ok
test simd::neon::tests::fwd_prefix_with_start_offset ... ok
test simd::neon::tests::movemask_0x80 ... ok
test simd::neon::tests::movemask_all_ones ... ok
test simd::neon::tests::movemask_all_zero ... ok
test simd::neon::tests::movemask_compare ... ok
test simd::neon::tests::movemask_mixed_values ... ok
test simd::neon::tests::movemask_single_bits ... ok
test simd::neon::tests::rev_prefix_at_chunk_boundaries ... ok
test simd::neon::tests::rev_prefix_char_class ... ok
test simd::neon::tests::rev_prefix_finds_last ... ok
test simd::neon::tests::rev_prefix_no_nibble_collision ... ok
test simd::neon::tests::rev_prefix_teddy1 ... ok
test simd::neon::tests::rev_prefix_size_sweep ... ok
test simd::neon::tests::rev_prefix_teddy2 ... ok
test simd::neon::tests::rev_prefix_teddy3 ... ok
test simd::neon::tests::rev_prefix_teddy3_second_chunk ... ok
test simd::neon::tests::rev_search_2bytes_long ... ok
test simd::neon::tests::rev_search_3bytes_long ... ok
test simd::neon::tests::rev_search_at_chunk_boundaries ... ok
test simd::neon::tests::rev_search_bytes_16 ... ok
test simd::neon::tests::rev_search_bytes_32 ... ok
test simd::neon::tests::rev_search_bytes_multi ... ok
test simd::neon::tests::rev_search_bytes_short ... ok
test simd::neon::tests::rev_search_size_sweep ... ok

test result: ok. 38 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/bin/build_byte_freq.rs (target/debug/deps/build_byte_freq-8257b1ccad412377)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/accel_skip_test.rs (target/debug/deps/accel_skip_test-7ec562e272f25849)

running 1 test
test accel_skip_lazy ... ignored, slow in debug; run with --ignored or in release

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/auto_harden_test.rs (target/debug/deps/auto_harden_test-2af8f0ae8da48f7b)

running 1 test
test auto_harden_toml ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s

     Running tests/deriv_test.rs (target/debug/deps/deriv_test-b1e7ad93ba0d9861)

running 1 test
test test_deriv_toml ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

     Running tests/dump.rs (target/debug/deps/dump-35c89c0bc3d24ff4)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/engine_test.rs (target/debug/deps/engine_test-c28ff87f3f246bc9)

running 114 tests
test accel_skip::accel_skip_lazy ... ignored, slow in debug; run with --ignored or in release
test dictionary_context_medium ... ignored, slow; run with --ignored
test anchored_alt_star_rejected ... ok
test capacity_exceeded_at_compile ... ok
test capacity_exceeded_at_match ... ok
test alt_embedded_line_anchor_compiles_ok ... ok
test empty_language_short_circuits ... ok
test anchored_rev_intersection_complement_missed_by_find_all ... ok
test fwd_la_1 ... ok
test dictionary_context_small_suffix ... ok
test alternation_prefix_soundness_bulk ... ok
test find_anchored ... ok
test errors ... ok
test fwd_la_2 ... ok
test dictionary_context_small_both ... ok
test hardened_boolean ... ignored, slow; run with --ignored
test fwd_la_2_js ... ok
test fwd_la_3 ... ok
test hardened_cross_validate_all_toml ... ignored, takes a while
test hardened_date_pattern ... ignored, slow; run with --ignored
test hardened_bounded_repeat_tail ... ok
test assets_path_js_unicode_uses_rev_literal ... ok
test anchored_fwd_lb_selected_when_min_len_zero_kind ... ok
test hardened_find_anchored ... ok
test dictionary_context_small ... ok
test hardened_nullable_empty_after_dedup ... ok
test hardened_paragraph ... ok
test hardened_pathological ... ok
test hardened_regressions::hardened_always_nullable_empty_matches ... ok
test hardened_semantics ... ignored, slow in debug; run with --ignored or in release
test hardened_word_boundary ... ignored, slow; run with --ignored
test internal ... ok
test ci ... ok
test intersect_narrow_with_widened_term_is_sound ... ok
test is_match_negative_lookahead ... ok
test hardened_basic ... ok
test auto_harden::auto_harden_toml ... ok
test hardened_long_word ... ok
test hardened_ci ... ok
test literal_alt_is_match ... ok
test literal_alt_suffix_is_match ... ok
test hardened_literal_alt ... ok
test literal_equiv_no_match ... ok
test literal_equiv_no_prefix ... ok
test literal_equiv_prefix_the ... ok
test literal_equiv_empty_input ... ok
test leading_union_lb_in_concat ... ok
test literal_prefix_char_class_no_prefix ... ok
test literal_prefix_alternation_at_root ... ok
test literal_prefix_pure_literal ... ok
test literal_prefix_single_char_pattern ... ok
test literal_prefix_with_wildcard ... ok
test literal_equiv_sherlock ... ok
test lookahead_alternation_with_end_of_line ... ok
test no_progress ... ok
test lookahead_rel_saturates_with_nested_quantified_lookahead ... ok
test lookahead_rel_saturates_with_end_anchor_intersection ... ok
test javascript ... ok
test js_numeric_literals ... ok
test hardened_cross_validate ... ok
test normal_basic ... ok
test literal_alt ... ok
test normalize_toml ... ok
test normal_paragraph ... ok
test not_word_boundary_before_upper_run ... ok
test opts_case_insensitive ... ok
test opts_dot_all_inline_flag ... ok
test opts_dot_all_scoped_group ... ok
test opts_dot_matches_new_line ... ok
test opts_ignore_whitespace ... ok
test opts_unicode_false ... ok
test not_word_boundary_thousands_sep ... ok
test parser_size::huge_repetitions_are_rejected ... ok
test parser_size::mixed_alt_and_intersection_top_level_does_not_panic ... ok
test precompiled_complex ... ok
test precompiled_matches_lazy ... ok
test prefix_calc_terminates_on_complement_intersection_quantified ... ok
test parser_size::deeply_nested_repetitions_rejected ... ok
test probe_alt::probe_alt ... ok
test probe_nettv::probe_nettv ... ok
test probe_nullable_prefix::probe_nullable_suffix ... ok
test edge_cases ... ok
test prefix_toml::test_prefix_toml ... ok
test reject_lookahead_in_loop ... ok
test repeat_limit_rejects_large_count ... ok
test hardened_cross_feature ... ok
test rev_bot_skip_terminates_fast ... ignored
test rev_literal_search ... ok
test semantics ... ignored, slow in debug; run with --ignored or in release
test hardened_edge_cases ... ok
test strip_lb_rejects_lookbehind_in_intersection ... ok
test trailing_dollar_after_top_star_pruned ... ok
test trailing_star_yields_to_fwd_prefix_kind ... ok
test unanchored_search_false_positive ... ok
test repeat_limit_unbounded_allows_large_count ... ok
test union_with_anchored_branch_mixed ... ok
test union_with_anchored_branch_simple ... ok
test range_prefix_random_haystack ... ok
test normal_cross_feature ... ok
test word_boundary_inference ... ignored, unsupported
test word_boundaries_loop ... ok
test union_with_word_boundary_branch ... ok
test space_newline_space ... ok
test word_match_lengths_en_sampled ... ok
test range_prefix_correctness ... ok
test normal_boolean ... ok
test word_boundary_between_word_chars_should_not_match ... ok
test date_pattern ... ok
test hardened_lookaround ... ok
test normal_lookaround ... ok
test hardened_anchors ... ok
test normal_anchors ... ok
test normal_word_boundary ... ok
test is_match_agrees_with_find_all ... ok

test result: ok. 104 passed; 0 failed; 10 ignored; 0 measured; 0 filtered out; finished in 3.29s

     Running tests/fuzz_compare.rs (target/debug/deps/fuzz_compare-b0de7575132fe864)

running 5 tests
test fuzz_npm ... ignored
test fuzz_pypi ... ignored
test fuzz_regexlib ... ignored
test fuzz_stackoverflow ... ignored
test fuzz_uniq ... ignored

test result: ok. 0 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/gen_schemas.rs (target/debug/deps/gen_schemas-8500ea659432a0e8)

running 1 test
test gen_schemas ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/neon_simd_test.rs (target/debug/deps/neon_simd_test-d5f953d65c477270)

running 75 tests
test all_accel_skip_patterns_simd_vs_default ... ignored, slow in debug; run with --ignored or in release
test class_pattern_in_1kb_haystack ... ok
test alternation_factored_prefix ... ok
test complement_simd ... ok
test anchored_end ... ok
test dot_pattern_long_haystack ... ok
test bounded_rep_multiple_at_boundaries ... ok
test empty_input ... ok
test alternation_with_suffix ... ok
test fwd_literal_adjacent_non_overlapping ... ok
test fwd_literal_bulk_find_all ... ok
test fwd_literal_single_byte_haystack ... ok
test fwd_literal_haystack_equals_needle ... ok
test anchored_start ... ok
test input_shorter_than_pattern ... ok
test is_match_class_lazy ... ok
test anchored_both ... ok
test is_match_lazy_long_input ... ok
test greedy_dot_star ... ok
test intersection_simd ... ok
test fwd_literal_near_end_boundary ... ok
test email_pattern ... ok
test ip_address_long_input ... ok
test fwd_literal_long_needle ... ok
test deep_alternation ... ok
test literal_in_64kb_haystack ... ok
test literal_in_1kb_haystack ... ok
test html_tag_pattern ... ok
test lookahead_with_simd ... ok
test many_single_char_matches ... ok
test many_two_char_matches ... ok
test lookbehind_with_simd ... ok
test match_spans_chunk_boundary ... ok
test non_overlapping_adjacent ... ok
test multiline_simd ... ok
test range_skip_digit_plus_has_accel ... ignored, reimplement prefix selection first
test one_byte_input ... ok
test range_skip_uppercase_in_long_input ... ok
test range_skip_uppercase_plus_has_accel ... ignored, reimplement prefix selection first
test neg_lookbehind_with_simd ... ok
test rev_range_skip_all_match ... ok
test rev_range_skip_no_match_long ... ok
test range_skip_ip_address ... ok
test quoted_string ... ok
test lazy_paragraph_toml ... ok
test rev_skip_all_match ... ok
test rev_skip_no_match_long ... ok
test rev_range_skip_size_sweep ... ok
test rev_range_skip_two_ranges ... ok
test fwd_literal_at_every_offset ... ok
test rev_skip_single_byte_every_position ... ok
test size_sweep_class ... ok
test teddy1_vowel_class ... ok
test teddy2_two_char_classes ... ok
test size_sweep_literal ... ok
test teddy3_three_char_classes ... ok
test teddy_at_end ... ok
test teddy_at_position_zero ... ok
test teddy_dense_matches ... ok
test rev_range_skip_digit_sweep ... ok
test rev_range_skip_uppercase_sweep ... ok
test teddy_pattern_no_match ... ok
test teddy_upper_lower_class ... ok
test teddy_alternation_three_way ... ok
test teddy_digit_class_sweep ... ok
test lazy_basic_toml ... ok
test rev_skip_two_bytes_sweep ... ok
test size_sweep_bounded_rep ... ok
test bounded_rep_size_sweep ... ok
test complement_intersection_simd ... ok
test lazy_edge_cases_toml ... ok
test lazy_semantics_toml ... ok
test lazy_boolean_toml ... ok
test lazy_lookaround_toml ... ok
test lazy_anchors_toml ... ok

test result: ok. 72 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.90s

     Running tests/parser.rs (target/debug/deps/parser-a6c5516b2e17f672)

running 3 tests
test mixed_alt_and_intersection_top_level_does_not_panic ... ok
test huge_repetitions_are_rejected ... ok
test deeply_nested_repetitions_rejected ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

     Running tests/properties_test.rs (target/debug/deps/properties_test-0b1971d73ed154ff)

running 36 tests
test bdfa_not_fixed ... ok
test bdfa_not_unbounded ... ok
test bdfa_bounded_repeat ... ok
test fixed_literal ... ok
test fixed_pred ... ok
test bdfa_aws_key ... ok
test fixed_repeat_range ... ok
test bdfa_not_look ... ok
test fixed_repeat_exact ... ok
test bdfa_phone_bounded ... ok
test fixed_union_different ... ok
test bdfa_union_variable ... ok
test bdfa_alt_suffix ... ok
test inf_dotstar_prefix ... ok
test inf_literal ... ok
test inf_star ... ok
test fixed_union_same ... ok
test inf_optional ... ok
test inf_plus ... ok
test look_lookahead ... ok
test look_lookbehind ... ok
test inf_bounded ... ok
test look_none ... ok
test minmax_alt_suffix ... ok
test minmax_aws_key ... ok
test minmax_literal ... ok
test minmax_bounded_repeat ... ok
test minmax_optional ... ok
test minmax_concat_bounded ... ok
test minmax_plus ... ok
test minmax_dotstar_literal ... ok
test minmax_star ... ok
test minmax_union ... ok
test look_word_boundary ... ok
test dispatch_literal ... ok
test dispatch_word_boundary_the ... ok

test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

     Running tests/rev_nulls_test.rs (target/debug/deps/rev_nulls_test-8429c5dba7e54ffe)

running 1 test
test test_rev_nulls_toml ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s

     Running tests/seek.rs (target/debug/deps/seek-bda1bfc945a43b85)

running 5 tests
test seek_fwd_from_offset_skips_earlier_matches ... ok
test seek_rev_from_offset_skips_later_matches ... ok
test seek_fwd_walks_all_matches ... ok
test seek_fwd_respects_word_boundary ... ok
test seek_rev_walks_all_matches_rightmost_first ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

     Running tests/stream.rs (target/debug/deps/stream-9b1f75b60763c599)

running 11 tests
test seek_fwd_with_class_pattern ... ok
test seek_no_match ... ok
test test_stream_chunk ... ok
test test_stream_with_callback ... ok
test seek_fwd_skips_match_before_pos ... ok
test test_cross_chunk_boundary ... ok
test seek_fwd_rev_cursor ... ok
test seek_rev_from_middle ... ok
test seek_fwd_from_middle ... ok
test stream_toml ... ok
test test_stream_prefix_skip_helps ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

=> 0
```




</details>