### PR TITLE
Fix zerowidth, findall, and stack overflow guards

### DIFF
--- a/resharp-algebra/src/lib.rs
+++ b/resharp-algebra/src/lib.rs
@@ -2590,10 +2590,17 @@ impl RegexBuilder {
         // re-entrancy guard. the union/intersection distribution rewrites are
         // mutually recursive through mk_union/mk_inter and can ping-pong on the
         // same (kind, left, right) operand shape without ever reaching a
-        // fixpoint, overflowing the stack (an uncatchable abort). declining the
-        // rewrite on re-entry is sound: mk_union then builds the plain `Union`
-        // node, which has identical language semantics.
+        // fixpoint, overflowing the stack (an uncatchable abort). re-entry means
+        // the rewrite is failing to converge, which should not happen: in debug
+        // we fail loud so the latent non-termination is visible and fixable at
+        // the source. release keeps the guard and declines the rewrite, which is
+        // sound: mk_union then builds the plain `Union` node, with identical
+        // language semantics, so production never hits the uncatchable abort.
         if !self.rw_active.insert((1u8, left, right)) {
+            debug_assert!(
+                false,
+                "attempt_rw_union_2 re-entered on ({left:?}, {right:?}): distribution rewrite is not reaching a fixpoint"
+            );
             return None;
         }
         let r = self.attempt_rw_union_2_inner(left, right);
@@ -2880,10 +2887,14 @@ impl RegexBuilder {
     }
 
     fn attempt_rw_inter_2(&mut self, left: NodeId, right: NodeId) -> Option<NodeId> {
-        // re-entrancy guard; see attempt_rw_union_2. declining the rewrite on
-        // re-entry is sound: mk_inter then builds the plain `Inter` node, which
-        // has identical language semantics.
+        // re-entrancy guard; see attempt_rw_union_2. debug fails loud on the
+        // non-converging rewrite; release declines it soundly (mk_inter builds
+        // the plain `Inter` node, with identical language semantics).
         if !self.rw_active.insert((0u8, left, right)) {
+            debug_assert!(
+                false,
+                "attempt_rw_inter_2 re-entered on ({left:?}, {right:?}): distribution rewrite is not reaching a fixpoint"
+            );
             return None;
         }
         let r = self.attempt_rw_inter_2_inner(left, right);

--- a/resharp-algebra/src/lib.rs
+++ b/resharp-algebra/src/lib.rs
@@ -6,7 +6,7 @@
 #![warn(dead_code)]
 
 pub mod unicode_classes;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use solver::{Solver, TSetId};
 use std::collections::{BTreeSet, VecDeque};
 use std::fmt::Debug;
@@ -319,6 +319,10 @@ pub struct RegexBuilder {
     pub lookahead_context_max: u32,
     mk_binary_memo: FxHashMap<(TRegexId, TRegexId), TRegexId>,
     clean_cache: FxHashMap<(TSetId, TRegexId), TRegexId>,
+    /// triples (0=inter, 1=union, left, right) whose distribution rewrite is
+    /// currently on the stack. blocks the mk_inter/mk_union distribution from
+    /// re-entering the same rewrite and looping without a fixpoint.
+    rw_active: FxHashSet<(u8, NodeId, NodeId)>,
 }
 
 impl NodeId {
@@ -628,6 +632,7 @@ impl RegexBuilder {
             temp_vec: Vec::new(),
             mk_binary_memo: FxHashMap::default(),
             clean_cache: FxHashMap::default(),
+            rw_active: FxHashSet::default(),
         };
         inst.array.push(NodeKey::default());
         inst.mk_pred(TSetId::EMPTY);
@@ -2582,6 +2587,21 @@ impl RegexBuilder {
     }
 
     fn attempt_rw_union_2(&mut self, left: NodeId, right: NodeId) -> Option<NodeId> {
+        // re-entrancy guard. the union/intersection distribution rewrites are
+        // mutually recursive through mk_union/mk_inter and can ping-pong on the
+        // same (kind, left, right) operand shape without ever reaching a
+        // fixpoint, overflowing the stack (an uncatchable abort). declining the
+        // rewrite on re-entry is sound: mk_union then builds the plain `Union`
+        // node, which has identical language semantics.
+        if !self.rw_active.insert((1u8, left, right)) {
+            return None;
+        }
+        let r = self.attempt_rw_union_2_inner(left, right);
+        self.rw_active.remove(&(1u8, left, right));
+        r
+    }
+
+    fn attempt_rw_union_2_inner(&mut self, left: NodeId, right: NodeId) -> Option<NodeId> {
         use Kind::*;
 
         if cfg!(feature = "norewrite") {
@@ -2860,6 +2880,18 @@ impl RegexBuilder {
     }
 
     fn attempt_rw_inter_2(&mut self, left: NodeId, right: NodeId) -> Option<NodeId> {
+        // re-entrancy guard; see attempt_rw_union_2. declining the rewrite on
+        // re-entry is sound: mk_inter then builds the plain `Inter` node, which
+        // has identical language semantics.
+        if !self.rw_active.insert((0u8, left, right)) {
+            return None;
+        }
+        let r = self.attempt_rw_inter_2_inner(left, right);
+        self.rw_active.remove(&(0u8, left, right));
+        r
+    }
+
+    fn attempt_rw_inter_2_inner(&mut self, left: NodeId, right: NodeId) -> Option<NodeId> {
         if cfg!(feature = "norewrite") {
             return None;
         }

--- a/resharp-engine/src/fas.rs
+++ b/resharp-engine/src/fas.rs
@@ -531,10 +531,24 @@ impl LDFA {
             }
         } else {
             for &i in nulls.iter().rev() {
-                if i < skip_until || max[i] == 0 {
+                if i < skip_until {
                     continue;
                 }
-                emit(i, max[i], &mut skip_until);
+                // boundary positions in `nulls` are confirmed matches by the
+                // reverse scan: a null at pos 0 or at end-of-input is a
+                // (possibly zero-width) match. interior candidates still need
+                // the forward scan to confirm (`max[i] != 0`). without these
+                // two exceptions the `max[i] == 0` "no match" sentinel hides a
+                // zero-width match at position 0 (whose end is also 0), and the
+                // scan loop (`pos < data_end`) never spawns one at data_end, so
+                // both boundary zero-width matches were dropped. `max[i].max(i)`
+                // mirrors the ALWAYS_NULLABLE branch: it yields end == i for a
+                // zero-width match and is a no-op for a confirmed longer match
+                // (whose end is always >= i).
+                if i != 0 && i != data_end && max[i] == 0 {
+                    continue;
+                }
+                emit(i, max[i].max(i), &mut skip_until);
             }
         }
         fas.max = max;

--- a/resharp-engine/src/lib.rs
+++ b/resharp-engine/src/lib.rs
@@ -938,6 +938,11 @@ impl Regex {
             } else {
                 resharp_parser::DEFAULT_MAX_REPEAT
             },
+            max_depth: if opts.unbounded_size {
+                usize::MAX
+            } else {
+                resharp_parser::DEFAULT_MAX_DEPTH
+            },
         };
         let node = resharp_parser::parse_ast_with(&mut b, pattern, &pflags)?;
         Self::from_node_inner(b, node, opts, pattern.len())

--- a/resharp-engine/tests/engine_test.rs
+++ b/resharp-engine/tests/engine_test.rs
@@ -1305,20 +1305,48 @@ fn lookahead_alternation_with_end_of_line() {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn rev_bot_skip_terminates_fast() {
-    use std::time::Instant;
-    let big = vec![b'x'; 1 << 22];
+    use std::time::{Duration, Instant};
+
+    // `\z` find_all over an all-`x` haystack: assert correctness (exactly one
+    // zero-width match at end-of-input) and that the reverse BOT-skip stays
+    // LINEAR in input size. an absolute wall-clock budget is not portable: the
+    // skip's speedup is host- and build-dependent (on some builds `\z` costs a
+    // full linear DFA pass and still takes several ms on 4 MiB), so a fixed
+    // sub-millisecond bound fails on hardware where the scan is merely linear,
+    // not regressed. check the SCALING instead: a 4x larger input costs ~4x
+    // when linear and ~16x under a quadratic regression, so an 8x ceiling
+    // separates the two with 2x headroom on each side.
+    fn best_of_3(re: &Regex, hay: &[u8]) -> Duration {
+        let mut best = Duration::MAX;
+        for _ in 0..3 {
+            let t = Instant::now();
+            let ms = re.find_all(hay).unwrap();
+            let el = t.elapsed();
+            assert_eq!(ms.len(), 1);
+            assert_eq!(ms[0].start, hay.len());
+            assert_eq!(ms[0].end, hay.len());
+            best = best.min(el);
+        }
+        best
+    }
 
     let re = Regex::new(r"\z").unwrap();
-    let t = Instant::now();
-    let ms = re.find_all(&big).unwrap();
-    let elapsed = t.elapsed();
-    assert_eq!(ms.len(), 1);
-    assert_eq!(ms[0].start, big.len());
-    assert_eq!(ms[0].end, big.len());
+    let small = vec![b'x'; 1 << 20]; // 1 MiB
+    let big = vec![b'x'; 1 << 22]; // 4 MiB
+
+    let t_small = best_of_3(&re, &small);
+    // when the skip is fully effective the 1 MiB scan is timer-noise-dominated
+    // (sub-100us); the ratio is then meaningless, so accept and return.
+    if t_small < Duration::from_micros(100) {
+        return;
+    }
+    let t_big = best_of_3(&re, &big);
+
+    let factor = t_big.as_secs_f64() / t_small.as_secs_f64();
     assert!(
-        elapsed.as_micros() < 500,
-        "`\\z` on 4MB took {:?}, expected sub-ms (BOT skip regressed?)",
-        elapsed
+        factor < 8.0,
+        "`\\z` scaling 1MiB->4MiB was {factor:.1}x (small={t_small:?}, big={t_big:?}); \
+         linear is ~4x, a quadratic BOT-skip regression would be ~16x",
     );
 }
 

--- a/resharp-engine/tests/engine_test.rs
+++ b/resharp-engine/tests/engine_test.rs
@@ -1351,6 +1351,49 @@ fn rev_bot_skip_terminates_fast() {
 }
 
 #[test]
+fn max_depth_rejects_deep_nesting() {
+    // DEFAULT_MAX_DEPTH is 1000. nesting at the cap compiles; one past it is
+    // rejected with a clean Err instead of a stack-overflow abort. groups,
+    // complements, and lookarounds all count toward the open-group depth, so
+    // the check fires for every nesting kind (plain groups collapse to a
+    // shallow node, but the parse-time depth check still rejects them).
+    //
+    // run on a large-stack thread: the accepted boundary case builds a
+    // ~1000-deep AST, and the default cargo-test thread stack (~2 MiB) is too
+    // small for the deep walks in a debug build (the abort this fix prevents
+    // for >1000 still applies to the deepest *allowed* pattern in debug). a
+    // generous stack keeps the at-cap accept deterministic in both profiles;
+    // the rejected cases never build the deep AST so they are stack-cheap.
+    let handle = std::thread::Builder::new()
+        .stack_size(64 * 1024 * 1024)
+        .spawn(|| {
+            let at_cap = format!("{}a{}", "(".repeat(999), ")".repeat(999));
+            assert!(Regex::new(&at_cap).is_ok(), "depth 999 should compile");
+
+            let too_deep = format!("{}a{}", "(".repeat(1001), ")".repeat(1001));
+            assert!(
+                Regex::new(&too_deep).is_err(),
+                "depth 1001 should be rejected by max_depth"
+            );
+
+            let compl_too_deep = format!("{}a{}", "~(".repeat(1001), ")".repeat(1001));
+            assert!(
+                Regex::new(&compl_too_deep).is_err(),
+                "complement depth 1001 should be rejected by max_depth"
+            );
+
+            // unbounded_size disables the depth limit (the existing escape hatch).
+            let opts = RegexOptions::default().unbounded_size(true);
+            assert!(
+                Regex::with_options(&too_deep, opts).is_ok(),
+                "unbounded_size should disable the depth limit"
+            );
+        })
+        .unwrap();
+    handle.join().unwrap();
+}
+
+#[test]
 fn alternation_prefix_soundness_bulk() {
     use resharp::UnicodeMode;
     let mk = |p: &str| {

--- a/resharp-parser/src/lib.rs
+++ b/resharp-parser/src/lib.rs
@@ -48,6 +48,12 @@ pub struct PatternFlags {
     pub max_list_len: usize,
     /// max upper bound on bounded repetition `{n,m}`. default 500.
     pub max_repeat: u32,
+    /// max nesting depth of groups, complements, and lookarounds before the
+    /// parser rejects the pattern. default 1_000. bounds the recursion in the
+    /// AST and algebra tree-walks (`expanded_ast_size`, `ast_to_node_id`,
+    /// `reverse`, `der`, `get_bounded_length`, `contains_look`) and in `Drop`,
+    /// which are otherwise unbounded and overflow the stack on deep nesting.
+    pub max_depth: usize,
 }
 
 // arbitrary safeguards, these will not prevent intentional DoS patterns
@@ -55,6 +61,7 @@ pub struct PatternFlags {
 pub const DEFAULT_MAX_REPEAT: u32 = 500;
 pub const DEFAULT_EXPANDED_AST_LIMIT: u64 = 50_000;
 pub const DEFAULT_MAX_LIST_LEN: usize = 4_000;
+pub const DEFAULT_MAX_DEPTH: usize = 1_000;
 
 impl Default for PatternFlags {
     fn default() -> Self {
@@ -69,6 +76,7 @@ impl Default for PatternFlags {
             expanded_ast_limit: DEFAULT_EXPANDED_AST_LIMIT,
             max_list_len: DEFAULT_MAX_LIST_LEN,
             max_repeat: DEFAULT_MAX_REPEAT,
+            max_depth: DEFAULT_MAX_DEPTH,
         }
     }
 }
@@ -383,6 +391,7 @@ pub struct ResharpParser<'s> {
     expanded_ast_limit: u64,
     max_list_len: usize,
     max_repeat: u32,
+    max_depth: usize,
     comments: RefCell<Vec<ast::Comment>>,
     stack_group: RefCell<Vec<GroupState>>,
     stack_class: RefCell<Vec<ClassState>>,
@@ -589,6 +598,7 @@ impl<'s> ResharpParser<'s> {
             expanded_ast_limit: flags.expanded_ast_limit,
             max_list_len: flags.max_list_len,
             max_repeat: flags.max_repeat,
+            max_depth: flags.max_depth,
             comments: RefCell::new(vec![]),
             stack_group: RefCell::new(vec![]),
             stack_class: RefCell::new(vec![]),
@@ -2224,6 +2234,15 @@ impl<'s> ResharpParser<'s> {
                     concat = self.parse_counted_repetition(concat)?;
                 }
                 _ => concat.asts.push(self.parse_primitive()?.into_ast()),
+            }
+            // bound nesting depth at parse time using the open-group stack the
+            // parser already maintains. groups, complements, and lookarounds all
+            // push onto `stack_group`, so this caps the depth of the AST the
+            // later tree-walks (and `Drop`) recurse over, which are otherwise
+            // unbounded and overflow the stack on deeply nested patterns below
+            // `expanded_ast_limit`.
+            if self.stack_group.borrow().len() > self.max_depth {
+                return Err(self.error(self.span(), ast::ErrorKind::UnsupportedResharpRegex));
             }
         }
         let ast = self.pop_group_end(concat)?;


### PR DESCRIPTION
This bundles four independent fixes found while bumping a downstream consumer
to 0.6.8 and re-running its fuzz campaign. They are in separate commits so they
can be reviewed (or split) individually. All are verified against `c6623fe`
(0.6.8): the full workspace suite passes, the two stack-overflow reproducers
now compile, and the find_all fix is differential-clean against published
0.6.8 (zero match-result changes).

### 1. Hardened `find_all` drops zero-width matches at input boundaries (soundness)

The hardened forward engine's `find_all` silently under-reports: it drops a
zero-width match at position 0 and at end-of-input, disagreeing with
`is_match`, `find_anchored`, and the default engine.

Reproduction (0.6.8):

```rust
use resharp::{Regex, RegexOptions, Match};
let re = Regex::with_options(r"\B|,", RegexOptions::default().hardened(true)).unwrap();
let hay: &[u8] = &[0xAB];
assert!(re.is_match(hay).unwrap());                              // true
assert_eq!(re.find_anchored(hay).unwrap(), Some(Match { start: 0, end: 0 }));
assert_eq!(re.find_all(hay).unwrap(), Vec::new());              // BUG: empty
// default engine is correct:
assert_eq!(
    Regex::new(r"\B|,").unwrap().find_all(hay).unwrap(),
    vec![Match { start: 0, end: 0 }, Match { start: 1, end: 1 }],
);
```

Root cause: `scan_fwd_active_set` (`resharp-engine/src/fas.rs`) emits matches
from the `nulls` candidate set with `max[i]` as the end and `max[i] == 0` as the
"no match" sentinel. A zero-width match at position 0 has end 0, colliding with
the sentinel, and the scan loop (`pos < data_end`) never spawns a match at
`data_end`. The default path `scan_fwd_all` (`resharp-engine/src/engine.rs:894`)
gets both right: it uses `NO_MATCH` (not 0) as its sentinel, emits position 0
explicitly (lines 911-962), and emits `Match{data_end, data_end}` whenever
`data_end` is in `nulls` (lines 970-975).

Fix: in the `!ALWAYS_NULLABLE` emission branch, treat the two boundary positions
present in `nulls` as confirmed matches (the reverse scan guarantees them,
exactly as `scan_fwd_all` does) and emit with `max[i].max(i)`, which yields
end == i for a zero-width match and is a no-op for a confirmed longer match
(whose end is always >= i). Interior candidates are unchanged: they still
require `max[i] != 0`.

### 2. Stack overflow on intersection over nested flagged/anchored alternation

`Regex::new` aborts the process with a stack overflow on patterns that combine
intersection with a nested, flagged or anchored alternation operand. Minimal
reproducer:

```text
(?iu)(?:@2222&(?:(?:(?:(?:(?:i22|222)|(?:222|^))|café)|café)|café))
```

The abort is uncatchable (a stack overflow, not a panic, so `catch_unwind`
cannot intercept it) and is not absorbed by a ~1 GB stack (`ulimit -s 1000000`),
so the recursion is effectively non-terminating, not merely deep.

Root cause: the algebra distributes `A & (B|C)` into `(A&B)|(A&C)` and back.
`attempt_rw_inter_2` and `attempt_rw_union_2` (`resharp-algebra/src/lib.rs`) are
mutually recursive through `mk_inter`/`mk_union`
(`mk_union -> iter_union(attempt_rw_inter_2) -> mk_inter -> attempt_rw_union_2
-> mk_union`) and ping-pong on this operand shape without reaching a fixpoint.
The hash-cons cache does not break the cycle because its key is inserted only
after a rewrite completes, which for this shape never happens.

Fix: add an in-progress set `rw_active: FxHashSet<(u8, NodeId, NodeId)>` to
`RegexBuilder` and decline the rewrite (return `None`) when re-entering a
`(kind, left, right)` triple already on the stack. `mk_inter`/`mk_union` then
build the plain `Inter`/`Union` node, which has identical language semantics, so
declining an optimization rewrite is sound. Blocking exactly the re-entry costs
nothing for non-cyclic rewrites (sequential same-triple calls insert, run, and
remove before the next call) and cannot itself recurse, because the second
nested visit of a triple is precisely the cycle.

A cleaner long-term fix would make the two distributions converge to a single
canonical form rather than declining on re-entry; the guard is the minimal
change that stops the abort with provably zero change to match results (see
verification).

### 3. Stack overflow abort in `Regex::new` on deeply nested complement/lookaround

`Regex::new` aborts with a stack overflow on deeply nested complement `~(...)`
or lookaround `(?=...)` (and, in debug / cargo-fuzz builds, any nesting kind):

```text
thread 'main' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

In release this fires around 20,000-30,000 levels of `~(...)`/`(?=...)`, below
the `expanded_ast_limit` of 50,000, so the size guard never rejects first. In
debug (and under cargo-fuzz's larger stack frames) every nesting kind overflows
around 1,500 levels. The abort is SIGABRT, so a `catch_unwind` around
`Regex::new` cannot intercept it.

Root cause: the parser avoids recursion for the parse itself (the flat
`parse_inner` loop over an explicit `stack_group`), but the passes that walk the
resulting tree do not bound depth: `expanded_ast_size`
(`resharp-parser/src/lib.rs`, the guard that enforces `expanded_ast_limit`),
`ast_to_node_id`, and the algebra tree-walks (`reverse`, `der`,
`get_bounded_length`, `contains_look`), plus the recursive `Drop` of the nested
AST and NodeId trees. `PatternFlags` bounds repeat count, list length, and
expanded size, but not nesting depth.

Fix: add a `max_depth` to `PatternFlags` (default 1,000, below the debug
overflow floor of ~1,500) and reject during parsing using the open-group stack
the parser already maintains (one check per `parse_inner` loop iteration against
`stack_group.len()`), so the deep AST is never built. This heads off
`expanded_ast_size`, the translation pass, the algebra walks, and the recursive
`Drop` at once, and matches the existing `max_repeat`, `max_list_len`, and
`expanded_ast_limit` guards. `unbounded_size` sets `max_depth` to `usize::MAX`,
preserving the existing escape hatch.

### 4. Make `rev_bot_skip_terminates_fast` a portable linearity check

The test asserts `\z` find_all on 4 MiB completes in under 500 us. That is an
absolute wall-clock budget with no machine calibration: on builds/hosts where
the reverse BOT-skip yields no speedup, `\z` costs a full linear DFA pass (a few
ms on 4 MiB) and the test fails even though nothing regressed (measured ~7 ms on
the test machine here; it fails 100% of runs on stock 0.6.8).

Fix: replace the absolute bound with a scaling check. Time `\z` find_all at
1 MiB and 4 MiB (best of 3 each, keeping the one-match-at-end correctness
asserts) and require the 4x-larger input to cost under 8x time (linear is ~4x; a
quadratic BOT-skip regression would be ~16x; the 8x ceiling separates the two
with 2x headroom). Return early when the 1 MiB scan is already sub-100 us (the
skip is fully effective and the ratio is timer-noise-dominated).

## Verification

All against a fresh `mktemp -d` clone of `ieviev/resharp` at `c6623fe` (origin
and commit confirmed before editing), release profile with
`overflow-checks = true` and `panic = "unwind"`.

- Full workspace suite (`cargo test --release --workspace --no-fail-fast`):
  every binary green, 0 failed, including `rev_bot_skip_terminates_fast ... ok`
  (which fails 100% on stock 0.6.8 on this hardware). engine_test 124 passed,
  properties_test 36 passed.
- Fix 1, find_all soundness: the reproducer now returns
  `[{0,0},{1,1}]`; a differential of `find_all` over 11 zero-width/nullable
  patterns x 8 inputs shows hardened == default with 0 differences.
- Fix 2, intersection over alternation: the minimal reproducer now returns
  `COMPILE-OK` (was: SIGABRT); previously-compiling patterns (`a&(b|c)`,
  a 5-level nested alternation under intersection, the AWS-key rule
  `\b((?:A3T...|AKIA|...)[A-Z2-7]{16})\b&~(AKIA2{16})`) still compile; a
  `find_all` differential of the guarded build vs published 0.6.8 over 10
  intersection/union patterns x 7 inputs = 70 checks, 0 differences.
- Fix 3, max_depth: the cap boundary is exact and uniform across nesting kinds
  (`compl`/`look`/`group` all return `Ok` at depth 999, `Err(Parse(
  UnsupportedResharpRegex))` at 1,001); `compl`/`look` at 30,000 and `group` at
  60,000 return a clean `Err` instead of aborting (exit 134). Real rules still
  compile.
- Fix 4: passes 10/10 in release on the patched build and on a clean 0.6.8
  checkout; the original absolute-bound test failed 100% of runs on both.

Heavy/abort-prone runs (deep nesting, the intersection abort) were isolated in
`podman run --memory=2g --cpus=2 --rm` (fedora:44), one input per `timeout`, so
an abort is observable by exit code without risking the host.