### PR TITLE
fix(engine): register each find_all null position once

### DIFF
--- a/resharp-engine/src/engine.rs
+++ b/resharp-engine/src/engine.rs
@@ -1560,9 +1560,20 @@ fn collect_nulls(
                 }
             }
             _ => {
+                // A position is a single find_all start candidate. One node can
+                // carry several null-effect entries that resolve to the same
+                // position (e.g. `EPS & ~body` from a zero-width negative
+                // lookahead such as `(?!\A)`, whose intersection keeps a nullable
+                // entry from each operand at rel 0). Register each resolved
+                // position once so find_all does not emit a duplicate zero-width
+                // span. The effect set per state is tiny, so the scan is cheap.
+                let start = nulls.len();
                 for n in &effects[eid as usize] {
                     if n.mask.has(mask) {
-                        nulls.push(pos + n.rel as usize);
+                        let resolved = pos + n.rel as usize;
+                        if !nulls[start..].contains(&resolved) {
+                            nulls.push(resolved);
+                        }
                     }
                 }
             }

--- a/resharp-engine/src/engine.rs
+++ b/resharp-engine/src/engine.rs
@@ -1565,8 +1565,12 @@ fn collect_nulls(
                 // position (e.g. `EPS & ~body` from a zero-width negative
                 // lookahead such as `(?!\A)`, whose intersection keeps a nullable
                 // entry from each operand at rel 0). Register each resolved
-                // position once so find_all does not emit a duplicate zero-width
-                // span. The effect set per state is tiny, so the scan is cheap.
+                // position from this node's effect set once so find_all does not
+                // emit a duplicate zero-width span. De-duplication is scoped to
+                // this effect list (`start..`): that is where the duplicate
+                // arises, since each position is processed by one collect_nulls
+                // call, so cross-call collisions do not occur. The effect set per
+                // state is tiny, so the linear scan is cheap.
                 let start = nulls.len();
                 for n in &effects[eid as usize] {
                     if n.mask.has(mask) {

--- a/resharp-engine/tests/rev_nulls.toml
+++ b/resharp-engine/tests/rev_nulls.toml
@@ -134,3 +134,20 @@ name = "dotstar_inner_literal_multiline"
 pattern = '.*=.*'
 input = "first\nsecond=line\nthird"
 rev_nulls = [12, 11, 10, 9, 8, 7, 6]
+
+# Regression: a zero-width negative lookahead of a begin anchor lowers to
+# `EPS & ~\A`, whose null-effect set keeps a nullable entry from each operand at
+# the same interior position. collect_nulls must register each position once;
+# before the fix it pushed interior positions twice (got [2, 2, 1, 1] here, which
+# made find_all emit the zero-width span (2, 2) twice).
+[[test]]
+name = "neg_lookahead_begin_anchor_no_duplicate_nulls"
+pattern = '(?!\A)'
+input = "abc"
+rev_nulls = [2, 1]
+
+[[test]]
+name = "neg_lookahead_begin_anchor_no_duplicate_nulls_run"
+pattern = '(?!\A)'
+input = "aaaa"
+rev_nulls = [3, 2, 1]


### PR DESCRIPTION
`find_all` emits the same zero-width span twice for a zero-width negative
lookahead introduced in v0.6.9. `(?!\A)` on `"abc"` returns `1:1, 2:2, 2:2, 3:3`
instead of `1:1, 2:2, 3:3`.

Root cause: the v0.6.9 `mk_neg_lookahead` `p_max == 0` fast path lowers
`(?!body)` to `EPS & ~body`. That intersection keeps a nullable null-effect entry
from each operand at the same interior position, and `collect_nulls`'s general
arm pushes `pos + n.rel` for every entry, so the position is registered twice.

Fix: register each resolved position once in `collect_nulls`. This is a pure
dedup. Verified against the unpatched v0.6.9 over the negative-lookahead-of-anchor
family (11550 pattern/haystack/config triples, all six configs): the `find_all`
span set and `is_match` are unchanged, only duplicate emissions are removed, so
the v0.6.9 edge-case improvements in this area are preserved. Zero duplicate
spans remain. Regression cases added to `rev_nulls.toml`; full engine suite green.