### PR TITLE
fix(parser): negate the byte class for ascii \D \S \W

### DIFF
--- a/resharp-engine/tests/semantics.toml
+++ b/resharp-engine/tests/semantics.toml
@@ -62,3 +62,55 @@ name = "semantic_lookbehind_boolean_log"
 pattern = '(?<=6|8\(|4|8|0\().*&~(.*\)\:.*)&\w.*&.*\w&.*(?=.*\)\:)&.*(?=\)\:|\)\:)'
 input = "\nJan 12 06:26:19: ACCEPT service http from 119.63.193.196 to firewall(pub-nic), prefix: \"none\" (in: eth0 119.63.193.196(5c:0a:5b:63:4a:82):4399 -> 140.105.63.164(50:06:04:92:53:44):80 TCP flags: ****S* len:60 ttl:32)\nJan 12 06:26:20: ACCEPT service dns from 140.105.48.16 to firewall(pub-nic-dns), prefix: \"none\" (in: eth0 140.105.48.16(00:21:dd:bc:95:44):4263 -> 140.105.63.158(00:14:31:83:c6:8d):53 UDP len:576 ttl:64)"
 matches = [[48, 137], [140, 179], [260, 354], [357, 396]]
+
+# Regression: in ascii mode the bare negated shorthands \D \S \W must negate the
+# byte class (consume exactly one non-class byte), not take the language
+# complement, which wrongly made them nullable and match "".
+[[test]]
+name = "ascii_neg_digit_not_nullable_empty"
+pattern = '\D'
+input = ""
+ascii = true
+matches = []
+
+[[test]]
+name = "ascii_neg_digit_rejects_digit"
+pattern = '\D'
+input = "5"
+ascii = true
+matches = []
+
+[[test]]
+name = "ascii_neg_digit_matches_nondigit"
+pattern = '\D'
+input = "x"
+ascii = true
+matches = [[0, 1]]
+
+[[test]]
+name = "ascii_neg_space_not_nullable_empty"
+pattern = '\S'
+input = ""
+ascii = true
+matches = []
+
+[[test]]
+name = "ascii_neg_word_not_nullable_empty"
+pattern = '\W'
+input = ""
+ascii = true
+matches = []
+
+[[test]]
+name = "ascii_neg_word_rejects_word_byte"
+pattern = '\W'
+input = "_"
+ascii = true
+matches = []
+
+[[test]]
+name = "ascii_star_then_neg_digit_requires_nondigit"
+pattern = 'a*\D'
+input = "0"
+ascii = true
+matches = []

--- a/resharp-parser/src/lib.rs
+++ b/resharp-parser/src/lib.rs
@@ -1370,7 +1370,12 @@ impl<'s> ResharpParser<'s> {
                         }
                     };
                     if negated {
-                        tb.mk_compl(pos)
+                        // Negate the byte class, not the whole language: `~(pos)`
+                        // (mk_compl) includes the empty string and every non-class
+                        // substring, so `\D`/`\S`/`\W` wrongly become nullable and
+                        // match "". neg_class negates within the single byte, as
+                        // the js branch above does.
+                        resharp_algebra::neg_class(tb, pos)
                     } else {
                         pos
                     }


### PR DESCRIPTION
In `UnicodeMode::Ascii` the bare negated shorthands `\D` `\S` `\W` wrongly match
the empty string. `is_match("")` returns `true` for each, and any pattern that
suffixes one inherits the wrong nullability (`a*\D` matches `""` and `"0"`).

Root cause: the ascii branch of `perl_class_node`
(`resharp-parser/src/lib.rs`) negates with `tb.mk_compl(pos)`, the regex
language-complement operator. `~(\w)` is every string that is not a single word
char, which includes `""`, so the class is nullable. The js branch a few lines
above already does the right thing with `resharp_algebra::neg_class(tb, pos)`
(negation within the single byte).

Fix: one line, use `neg_class` in the ascii branch too. Only the bare-shorthand
ascii path was wrong; default, full, js, and bracketed `[\D]`/`[^\w]` were
already correct, and matches the `regex` crate with `.unicode(false)`
byte-for-byte on the cases tested. Regression cases added to `semantics.toml`.