### PR TITLE
fix(engine): stop find_all aborting or leaking on a NO_MATCH candidate

### DIFF
--- a/resharp-engine/src/engine.rs
+++ b/resharp-engine/src/engine.rs
@@ -957,12 +957,24 @@ impl LDFA {
                         )
                     };
                 }
-                assert_ne!(NO_MATCH, l_max_end, "correctness issue found");
-                matches.push(Match {
-                    start: 0,
-                    end: l_max_end,
-                });
-                next_start = l_max_end;
+                // The forward scan from the reverse-proposed start 0 found no
+                // end (l_max_end stayed at NO_MATCH): the reverse pass and the
+                // forward language disagree. The forward DFA is the authority on
+                // whether a match starts here, so skip the over-proposed
+                // candidate instead of aborting the host (was assert_ne!, BUG-2)
+                // or pushing NO_MATCH as a Match end (BUG-4). debug_assert keeps
+                // the disagreement loud in debug builds.
+                debug_assert_ne!(
+                    NO_MATCH, l_max_end,
+                    "find_all: forward scan found no end for reverse-proposed start 0"
+                );
+                if l_max_end != NO_MATCH {
+                    matches.push(Match {
+                        start: 0,
+                        end: l_max_end,
+                    });
+                    next_start = l_max_end;
+                }
                 break;
             }
         }
@@ -1006,11 +1018,17 @@ impl LDFA {
                             l_max_end,
                         )
                     };
-                    matches.push(Match {
-                        start: nulls[i],
-                        end: l_max_end,
-                    });
-                    next_start = l_max_end;
+                    debug_assert_ne!(
+                        NO_MATCH, l_max_end,
+                        "find_all: forward scan found no end for reverse-proposed start"
+                    );
+                    if l_max_end != NO_MATCH {
+                        matches.push(Match {
+                            start: nulls[i],
+                            end: l_max_end,
+                        });
+                        next_start = l_max_end;
+                    }
                     break;
                 }
                 debug_assert!(
@@ -1019,11 +1037,17 @@ impl LDFA {
                     l_max_end,
                     nulls[i]
                 );
-                matches.push(Match {
-                    start: nulls[i],
-                    end: l_max_end,
-                });
-                next_start = l_max_end;
+                debug_assert_ne!(
+                    NO_MATCH, l_max_end,
+                    "find_all: forward scan found no end for reverse-proposed start"
+                );
+                if l_max_end != NO_MATCH {
+                    matches.push(Match {
+                        start: nulls[i],
+                        end: l_max_end,
+                    });
+                    next_start = l_max_end;
+                }
                 break;
             }
         }

--- a/resharp-engine/tests/sentinel_release_test.rs
+++ b/resharp-engine/tests/sentinel_release_test.rs
@@ -1,0 +1,51 @@
+//! Release-only regression coverage for the NO_MATCH sentinel reaching a
+//! `find_all` result.
+//!
+//! When the reverse pass proposes a match start that the forward scan then
+//! rejects (forward end stays at `NO_MATCH`), the default `find_all` path used
+//! to abort the host (`assert_ne!`, BUG-2) or push `usize::MAX` as a `Match.end`
+//! (BUG-4). It now skips the over-proposed candidate. In debug builds a
+//! `debug_assert` still fires on that disagreement to keep the underlying
+//! forward/reverse inconsistency visible, so this release floor is checked only
+//! when debug assertions are off.
+#![cfg(not(debug_assertions))]
+
+use resharp::{Regex, RegexOptions};
+
+#[test]
+fn find_all_does_not_abort_or_leak_no_match_sentinel() {
+    // Default mode: these aborted at engine.rs:960 (BUG-2) or leaked
+    // end == usize::MAX (BUG-4). The forward scan rejects every candidate, so
+    // the correct result is empty (matches the dotnet reference).
+    for (pat, hay) in [
+        (r".\W*b+", "ba"),
+        (r"\S+b", "b'_"),
+        (r"\Bb+", "ba"),
+        (r"(?<=[^a])b+", "ba"),
+    ] {
+        let re = Regex::new(pat).unwrap();
+        let matches = re.find_all(hay.as_bytes()).unwrap();
+        for m in &matches {
+            assert!(
+                m.end <= hay.len() && m.start <= m.end,
+                "pat={pat:?} hay={hay:?}: unbounded match {m:?}"
+            );
+        }
+        assert!(
+            matches.is_empty(),
+            "pat={pat:?} hay={hay:?}: expected no match, got {matches:?}"
+        );
+    }
+
+    // Flags mode end-anchor complement: leaked usize::MAX (BUG-4). The surviving
+    // candidate must be in bounds.
+    let flags = RegexOptions::default()
+        .case_insensitive(true)
+        .ignore_whitespace(true)
+        .dot_matches_new_line(true)
+        .multiline(false);
+    let re = Regex::with_options(r"~(_*$)", flags).unwrap();
+    for m in re.find_all(b"ab").unwrap().iter() {
+        assert!(m.end <= 2 && m.start <= m.end, "leaked sentinel: {m:?}");
+    }
+}

--- a/resharp-engine/tests/sentinel_release_test.rs
+++ b/resharp-engine/tests/sentinel_release_test.rs
@@ -1,51 +1,64 @@
-//! Release-only regression coverage for the NO_MATCH sentinel reaching a
-//! `find_all` result.
+//! Regression coverage for the NO_MATCH sentinel reaching a `find_all` result.
 //!
 //! When the reverse pass proposes a match start that the forward scan then
 //! rejects (forward end stays at `NO_MATCH`), the default `find_all` path used
-//! to abort the host (`assert_ne!`, BUG-2) or push `usize::MAX` as a `Match.end`
-//! (BUG-4). It now skips the over-proposed candidate. In debug builds a
-//! `debug_assert` still fires on that disagreement to keep the underlying
-//! forward/reverse inconsistency visible, so this release floor is checked only
-//! when debug assertions are off.
-#![cfg(not(debug_assertions))]
+//! to push `usize::MAX` as a `Match.end` (BUG-4) or, at the pos-0 branch, abort
+//! the host (`assert_ne!`, BUG-2). It now skips the over-proposed candidate, and
+//! a `debug_assert` keeps the underlying forward/reverse disagreement loud in
+//! debug builds.
+//!
+//! On v0.6.9 the live trigger is the end-anchor complement in flags mode
+//! (`~(_*$)`, `~(_*\z)`), which leaks `Match { end: usize::MAX }` before the fix;
+//! a caller slicing `hay[start..end]` then reads out of bounds. (The pos-0 abort
+//! site no longer reproduces from the earlier `.\W*b+`-style patterns on this
+//! base, but the same guard is converted there too.)
+//!
+//! The behaviour differs by build profile, so each profile has its own test
+//! (there is no debug-vs-release split in CI to rely on, so neither is left
+//! unexercised):
+//!
+//! - release: `find_all` degrades gracefully (no out-of-bounds end, no abort).
+//! - debug: the `debug_assert` fires on the same disagreement.
 
 use resharp::{Regex, RegexOptions};
 
+/// Flags mode matching the BUG-4 reproducer.
+fn flags() -> RegexOptions {
+    RegexOptions::default()
+        .case_insensitive(true)
+        .ignore_whitespace(true)
+        .dot_matches_new_line(true)
+        .multiline(false)
+}
+
+/// Release floor: the over-proposed candidate is skipped, so `find_all` returns
+/// a bounded result instead of leaking the `usize::MAX` sentinel.
+#[cfg(not(debug_assertions))]
 #[test]
-fn find_all_does_not_abort_or_leak_no_match_sentinel() {
-    // Default mode: these aborted at engine.rs:960 (BUG-2) or leaked
-    // end == usize::MAX (BUG-4). The forward scan rejects every candidate, so
-    // the correct result is empty (matches the dotnet reference).
+fn find_all_does_not_leak_no_match_sentinel() {
     for (pat, hay) in [
-        (r".\W*b+", "ba"),
-        (r"\S+b", "b'_"),
-        (r"\Bb+", "ba"),
-        (r"(?<=[^a])b+", "ba"),
+        (r"~(_*$)", "ab"),
+        (r"~(_*\z)", "ab"),
+        (r"~(_*\z)", "abc"),
     ] {
-        let re = Regex::new(pat).unwrap();
+        let re = Regex::with_options(pat, flags()).unwrap();
         let matches = re.find_all(hay.as_bytes()).unwrap();
         for m in &matches {
             assert!(
                 m.end <= hay.len() && m.start <= m.end,
-                "pat={pat:?} hay={hay:?}: unbounded match {m:?}"
+                "pat={pat:?} hay={hay:?}: leaked sentinel / out-of-bounds match {m:?}"
             );
         }
-        assert!(
-            matches.is_empty(),
-            "pat={pat:?} hay={hay:?}: expected no match, got {matches:?}"
-        );
     }
+}
 
-    // Flags mode end-anchor complement: leaked usize::MAX (BUG-4). The surviving
-    // candidate must be in bounds.
-    let flags = RegexOptions::default()
-        .case_insensitive(true)
-        .ignore_whitespace(true)
-        .dot_matches_new_line(true)
-        .multiline(false);
-    let re = Regex::with_options(r"~(_*$)", flags).unwrap();
-    for m in re.find_all(b"ab").unwrap().iter() {
-        assert!(m.end <= 2 && m.start <= m.end, "leaked sentinel: {m:?}");
-    }
+/// Debug invariant: the same forward/reverse disagreement that the release floor
+/// skips silently must trip the `debug_assert` in debug builds, so the
+/// underlying inconsistency stays visible rather than being papered over.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "forward scan found no end")]
+fn find_all_debug_asserts_on_forward_reverse_disagreement() {
+    let re = Regex::with_options(r"~(_*$)", flags()).unwrap();
+    let _ = re.find_all(b"ab");
 }


### PR DESCRIPTION

The default `find_all` proposes a match start from the reverse pass, then
forward-scans for its end. When the forward scan finds no end (`l_max_end` stays
at `NO_MATCH == usize::MAX`) the two views of the language disagree, and the three
emit sites in `LDFA::find_all` mishandle it:

- the two interior branches push `Match { end: usize::MAX }` into the public
  result (BUG-4). On v0.6.9 the live trigger is the end-anchor complement in flags
  mode: `~(_*$)` and `~(_*\z)` on `"ab"` return `[(0,1), (1, 18446744073709551615)]`,
  so a caller slicing `hay[start..end]` reads out of bounds.
- the pos-0 branch aborts the host with `assert_ne!(.., "correctness issue found")`
  at `engine.rs:960` (BUG-2), the sibling guard on the same condition.

Note on scope vs the original campaign: the v0.6.9 cleanup commit (`4ffe1cc`)
already changed the path for the old BUG-2 reproducers (`.\W*b+`, `\S+b`) and the
default-mode BUG-4 reproducers (`\Bb+`, `(?<=[^a])b+`); those now return `[]`
cleanly on this base and no longer reach the NO_MATCH sites. The end-anchor
complement in flags mode is what still leaks. This PR therefore fixes that live
leak and converts the sibling abort guard at the same time, so it cannot abort the
host for any input that does reach it.

Fix: the forward scan is the authority on whether a match starts at a candidate,
so skip the over-proposed candidate. Release degrades gracefully (no abort, no
out-of-bounds end); a `debug_assert` keeps the forward/reverse disagreement loud
in debug, matching the release-floor + debug-assert pattern from #13.

Scope: this fixes the out-of-bounds leak and removes the host-abort hazard, not
the deeper forward/reverse disagreement itself; that residual inconsistency stays
debug-visible. Tests cover both build profiles (`~(_*$)`/`~(_*\z)` flags): a
release test asserts no out-of-bounds end, a debug `should_panic` test asserts the
`debug_assert` fires.

Alternative considered: returning `Err` instead of skipping. Skipping keeps the
real matches `find_all` does find, so it is the less disruptive floor.