### PR TITLE
fix(engine): start the lookbehind-candidate search at 0 after a zero-width begin match

### DIFF
--- a/resharp-engine/src/fwd.rs
+++ b/resharp-engine/src/fwd.rs
@@ -120,7 +120,12 @@ fn fwd_lb_prefix_impl<const IS_MATCH: bool>(
                     return Ok(true);
                 }
             }
-            search_start = if max_end == 0 { 0 } else { max_end };
+            // Resume the candidate search at the begin match's end. After a
+            // zero-width begin match this restarts at 0, which cannot re-emit
+            // the begin match: a candidate at byte c produces a body match at
+            // c + lb_len, and lb_len >= 1, so candidate 0 yields the body
+            // position lb_len, not a rescan of position 0.
+            search_start = max_end;
         }
     }
 

--- a/resharp-engine/src/fwd.rs
+++ b/resharp-engine/src/fwd.rs
@@ -120,7 +120,7 @@ fn fwd_lb_prefix_impl<const IS_MATCH: bool>(
                     return Ok(true);
                 }
             }
-            search_start = if max_end == 0 { 1 } else { max_end };
+            search_start = if max_end == 0 { 0 } else { max_end };
         }
     }
 

--- a/resharp-engine/tests/engine_test.rs
+++ b/resharp-engine/tests/engine_test.rs
@@ -2365,6 +2365,43 @@ fn bug10_default_and_hardened_find_all_agree() {
 }
 
 #[test]
+fn findall_lb_prefix_keeps_offset1_zero_width() {
+    // The prefix-accelerated leading-lookbehind find_all driver
+    // (fwd_lb_prefix_impl) dropped the offset-1 zero-width match right after a
+    // leading zero-width begin match. `^$` over "\n\n" (three empty lines)
+    // matches at 0:0, 1:1, 2:2, but the SIMD-on (prefix-built) path returned
+    // [0:0, 2:2]; the scalar fallback and hardened path were already correct.
+    let hay: &[u8] = b"\n\n";
+    let def = resharp::Regex::new("^$").unwrap();
+    let hard = resharp::Regex::with_options(
+        "^$",
+        resharp::RegexOptions::default().hardened(true),
+    )
+    .unwrap();
+    let def_spans: Vec<(usize, usize)> = def
+        .find_all(hay)
+        .unwrap()
+        .iter()
+        .map(|m| (m.start, m.end))
+        .collect();
+    let hard_spans: Vec<(usize, usize)> = hard
+        .find_all(hay)
+        .unwrap()
+        .iter()
+        .map(|m| (m.start, m.end))
+        .collect();
+    assert_eq!(
+        def_spans,
+        vec![(0, 0), (1, 1), (2, 2)],
+        "default find_all(^$, \"\\n\\n\")={def_spans:?}, want [0:0,1:1,2:2]"
+    );
+    assert_eq!(
+        def_spans, hard_spans,
+        "default={def_spans:?} hardened={hard_spans:?} must agree"
+    );
+}
+
+#[test]
 fn bug12_neg_lookahead_class_not_nullable() {
     use resharp::Regex;
     let cases: &[&str] = &[

--- a/resharp-engine/tests/engine_test.rs
+++ b/resharp-engine/tests/engine_test.rs
@@ -2365,31 +2365,28 @@ fn bug10_default_and_hardened_find_all_agree() {
 }
 
 #[test]
-fn findall_lb_prefix_keeps_offset1_zero_width() {
+fn find_all_lb_prefix_keeps_offset1_zero_width() {
     // The prefix-accelerated leading-lookbehind find_all driver
     // (fwd_lb_prefix_impl) dropped the offset-1 zero-width match right after a
     // leading zero-width begin match. `^$` over "\n\n" (three empty lines)
     // matches at 0:0, 1:1, 2:2, but the SIMD-on (prefix-built) path returned
     // [0:0, 2:2]; the scalar fallback and hardened path were already correct.
     let hay: &[u8] = b"\n\n";
+    let spans = |re: &resharp::Regex| -> Vec<(usize, usize)> {
+        re.find_all(hay)
+            .unwrap()
+            .iter()
+            .map(|m| (m.start, m.end))
+            .collect()
+    };
     let def = resharp::Regex::new("^$").unwrap();
     let hard = resharp::Regex::with_options(
         "^$",
         resharp::RegexOptions::default().hardened(true),
     )
     .unwrap();
-    let def_spans: Vec<(usize, usize)> = def
-        .find_all(hay)
-        .unwrap()
-        .iter()
-        .map(|m| (m.start, m.end))
-        .collect();
-    let hard_spans: Vec<(usize, usize)> = hard
-        .find_all(hay)
-        .unwrap()
-        .iter()
-        .map(|m| (m.start, m.end))
-        .collect();
+    let def_spans = spans(&def);
+    let hard_spans = spans(&hard);
     assert_eq!(
         def_spans,
         vec![(0, 0), (1, 1), (2, 2)],


### PR DESCRIPTION
Fixes the single SIMD-path soundness divergence from a follow-up fuzz campaign
to #17, against v0.6.12 (`3d4ddde`). The prefilter-accelerated leading-lookbehind
`find_all` driver drops the offset-1 match immediately after a leading zero-width
match.

## Reproducer (stock v0.6.12, NEON or AVX2)

```rust
let re = Regex::new(r"^$").unwrap();
re.find_all(b"\n\n").unwrap();
// SIMD on : [0:0, 2:2]         <- missing 1:1
// SIMD off: [0:0, 1:1, 2:2]    <- correct
```

`"\n\n"` is three empty lines (positions 0, 1, 2), so `^$` matches at `0:0`,
`1:1`, and `2:2`. The accelerated path drops exactly the offset-1 match and gets
every other position right; on N consecutive newlines it returns
`0, 2, 3, ..., N`, missing only position 1. The result is byte-identical on NEON
(Apple M1) and AVX2 (x86-64), so the defect is in the architecture-independent
driver, not in `neon.rs` or the AVX2 intrinsics (which only locate the `\n` bytes,
correctly).

## Root cause

In `fwd_lb_prefix_impl`, after the zero-width begin match (`max_end == 0`) the
driver advances `search_start` to 1, then uses it as the lower bound for the
lookbehind-candidate search `fwd_prefix.find_fwd(input, search_start)`. A
candidate at byte `c` produces a body match at `c + lb_len`, so the candidate at
byte 0 (body position `0 + lb_len = 1`) is exactly the missed `1:1` match. The
candidate loop never emits `body_start = 0` on its own (`body_start >= lb_len >=
1`), so advancing to 1 is an off-by-`lb_len` overshoot of the candidate frame.

## Patch

```diff
@@ resharp-engine/src/fwd.rs:123  (fn fwd_lb_prefix_impl) @@
-            search_start = if max_end == 0 { 1 } else { max_end };
+            search_start = if max_end == 0 { 0 } else { max_end };
```

## Verification

With `{ 0 }` the SIMD-on path returns `[0:0, 1:1, 2:2]` for `^$` and the
divergence disappears across the campaign's adversarial corpus with no new
divergences. The candidate loop cannot re-emit the offset-0 match because its body
positions start at `lb_len >= 1`, so starting the candidate search at 0 is safe.

The one spot worth your eye: this driver gates every candidate through the
lookbehind, so a pattern that reaches `max_end == 0` without a leading lookbehind
should not enter this path at all and is therefore unaffected, but that invariant
is yours to confirm, not the corpus's.

## Regression test

This branch adds `findall_lb_prefix_keeps_offset1_zero_width` to
`resharp-engine/tests/engine_test.rs`: `^$` over `"\n\n"` must return
`[0:0, 1:1, 2:2]` and the default driver must agree with the hardened one. It
fails on the pre-fix engine (`[0:0, 2:2]`, the offset-1 match dropped) and passes
with the fix; the full `engine_test` suite stays green (149 passed, 0 failed).

## Provenance

Found by a `simd_diff` differential libFuzzer target on the M1 (NEON),
corroborated by a same-machine `has_simd()` on-vs-off differential and reproduced
on AVX2. A broader SIMD-prefilter on-vs-off differential harness (a runtime
override feeding the same assertion over a corpus) is possible later but needs an
engine hook, so this PR ships the focused unit regression above instead.
