### PR TITLE
refactor(algebra): remove an always-true bounded-length comparison

### DIFF
--- a/resharp-algebra/src/lib.rs
+++ b/resharp-algebra/src/lib.rs
@@ -1841,11 +1841,12 @@ impl RegexBuilder {
                 let rhs = node_id.right(self);
                 if lhs.is_pred_star(self).is_some() {
                     if let Some(opttail) = rhs.is_opt_v(self) {
-                        let (_, max) = self.get_min_max_length(node_id);
-                        if max <= u32::MAX {
-                            if let Some(true) = self.subsumes(lhs, opttail) {
-                                return Some(lhs);
-                            }
+                        // Previously gated on `max <= u32::MAX` for the concat's
+                        // max length, which is always true (and the lhs star
+                        // makes that max the unbounded sentinel unconditionally),
+                        // so the comparison was a no-op.
+                        if let Some(true) = self.subsumes(lhs, opttail) {
+                            return Some(lhs);
                         }
                     }
                 }


### PR DESCRIPTION



clippy's deny-by-default `absurd_extreme_comparisons` (a correctness-class
lint) fails the workspace on main today, at one site:

```txt
error: this comparison involving the minimum or maximum element for this type
       contains a case that is always true or always false
    --> resharp-algebra/src/lib.rs:1845:28
1845 |                         if max <= u32::MAX {
```

`max` is a `u32`, so `max <= u32::MAX` is always true and the guard around the
`subsumes(lhs, opttail)` rewrite in `post_init_simplify` is a no-op. This PR
removes the comparison, which preserves current behavior exactly: the full
workspace test suite passes unchanged, and clippy goes green (warnings stay,
but only the deny-level error fails the build).

One question before merging, because the dead guard looks like it wanted to be
a real one. `get_min_max_length` documents `u32::MAX` as the unbounded-length
sentinel (`lib.rs:1023`), so the plausible intended readings are:

- `max != u32::MAX` on the concat's own length: this cannot be it, because the
  `lhs.is_pred_star` precondition forces the concat's max length to the
  unbounded sentinel unconditionally, which would make the whole rewrite dead
  code;
- a boundedness check on the **optional tail** (`opttail`) rather than the
  concat, i.e. only subsume a bounded tail into the star;
- a vestigial check from an earlier shape of the rewrite, in which case
  removing it (this PR) is the final state.

If the second reading is the intent, say so and this PR switches to
`self.get_min_max_length(opttail)` with a real `!= u32::MAX` guard; as written
it takes the behavior-preserving option so the clippy signal is restored
without smuggling in a semantics change.

## Verification

- `cargo test --workspace`: green before and after (engine 148 passed,
  algebra 73, parser 36, plus the smaller suites).
- `cargo clippy --workspace --all-targets`: exit 1 on main (the error above),
  exit 0 with this change.
