### PR TITLE
ci: add test, clippy, and fuzz workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       # the dev/test profile keeps debug_assertions on, so the engine's
@@ -25,7 +25,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -37,7 +37,7 @@ jobs:
   fuzz-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,11 @@ jobs:
       # seed corpus (-runs=0 executes the corpus without random search), so
       # this job is reproducible and stays green unless a committed seed
       # regresses. random-search fuzzing lives in fuzz-nightly.yml, where a
-      # red run means a found bug rather than a broken push.
+      # red run means a found bug rather than a broken push. targets are
+      # enumerated with `cargo fuzz list` so new targets are covered the
+      # moment they land.
       - run: |
-          for target in compile diff_regex match_invariants; do
+          for target in $(cargo +nightly fuzz list); do
             cargo +nightly fuzz run "$target" -- -runs=0
           done
         working-directory: fuzz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: ci
 
+# third-party actions are pinned to commit SHAs (supply-chain hardening);
+# the trailing comment names the pinned tag or branch. the dtolnay pins are
+# channel branches: the channel is baked into the pinned action.yml and
+# rustup resolves it at run time, so the Rust version itself is not frozen.
+# cargo-fuzz is version-pinned so this job stays reproducible; bump both
+# deliberately.
+
 on: [push, pull_request, workflow_dispatch]
 
 env:
@@ -14,9 +21,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       # the dev/test profile keeps debug_assertions on, so the engine's
       # internal debug_assert! guards fail loudly here instead of being
       # compiled out.
@@ -25,11 +32,11 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       # warnings stay advisory (no -D warnings); deny-by-default lints
       # (correctness class) still fail the job.
       - run: cargo clippy --workspace --all-targets
@@ -37,21 +44,24 @@ jobs:
   fuzz-replay:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly branch
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: fuzz
-      - run: cargo install cargo-fuzz --locked
+      - run: cargo install cargo-fuzz --version 0.13.2 --locked
       # deterministic: builds every target and replays only the committed
       # seed corpus (-runs=0 executes the corpus without random search), so
       # this job is reproducible and stays green unless a committed seed
       # regresses. random-search fuzzing lives in fuzz-nightly.yml, where a
       # red run means a found bug rather than a broken push. targets are
       # enumerated with `cargo fuzz list` so new targets are covered the
-      # moment they land.
+      # moment they land; every target is attempted even if an earlier one
+      # fails, and the job fails at the end if any did.
       - run: |
+          failed=0
           for target in $(cargo +nightly fuzz list); do
-            cargo +nightly fuzz run "$target" -- -runs=0
+            cargo +nightly fuzz run "$target" -- -runs=0 || failed=1
           done
+          exit "$failed"
         working-directory: fuzz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       # (correctness class) still fail the job.
       - run: cargo clippy --workspace --all-targets
 
-  fuzz-smoke:
+  fuzz-replay:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -43,10 +43,13 @@ jobs:
         with:
           workspaces: fuzz
       - run: cargo install cargo-fuzz --locked
-      # a short deterministic-budget run per target: catches build rot and
-      # shallow regressions; the committed seed-* corpus keeps it reproducible.
+      # deterministic: builds every target and replays only the committed
+      # seed corpus (-runs=0 executes the corpus without random search), so
+      # this job is reproducible and stays green unless a committed seed
+      # regresses. random-search fuzzing lives in fuzz-nightly.yml, where a
+      # red run means a found bug rather than a broken push.
       - run: |
           for target in compile diff_regex match_invariants; do
-            cargo +nightly fuzz run "$target" -- -max_total_time=30
+            cargo +nightly fuzz run "$target" -- -runs=0
           done
         working-directory: fuzz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: ci
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        # macos-latest is arm64, so the NEON SIMD paths get exercised;
+        # ubuntu-latest covers AVX2.
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # the dev/test profile keeps debug_assertions on, so the engine's
+      # internal debug_assert! guards fail loudly here instead of being
+      # compiled out.
+      - run: cargo test --workspace
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      # warnings stay advisory (no -D warnings); deny-by-default lints
+      # (correctness class) still fail the job.
+      - run: cargo clippy --workspace --all-targets
+
+  fuzz-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz
+      - run: cargo install cargo-fuzz --locked
+      # a short deterministic-budget run per target: catches build rot and
+      # shallow regressions; the committed seed-* corpus keeps it reproducible.
+      - run: |
+          for target in compile diff_regex match_invariants; do
+            cargo +nightly fuzz run "$target" -- -max_total_time=30
+          done
+        working-directory: fuzz

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -4,6 +4,8 @@ name: fuzz-nightly
 # here means libFuzzer found a real input (the crash artifact is uploaded),
 # not that a push broke the build. while known crashers are open this will
 # fail by design; that is the job doing its work.
+#
+# action and cargo-fuzz pinning policy: see the comment in ci.yml.
 on:
   schedule:
     - cron: "17 4 * * *"
@@ -16,12 +18,12 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly branch
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: fuzz
-      - run: cargo install cargo-fuzz --locked
+      - run: cargo install cargo-fuzz --version 0.13.2 --locked
       # targets are enumerated with `cargo fuzz list` so new targets are
       # covered the moment they land; every target runs even if an earlier
       # one finds a crash, and the job fails if any did.
@@ -32,7 +34,7 @@ jobs:
           done
           exit "$failed"
         working-directory: fuzz
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           name: fuzz-artifacts

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -14,10 +14,6 @@ env:
 
 jobs:
   fuzz:
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [compile, diff_regex, match_invariants]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -26,11 +22,19 @@ jobs:
         with:
           workspaces: fuzz
       - run: cargo install cargo-fuzz --locked
-      - run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=600
+      # targets are enumerated with `cargo fuzz list` so new targets are
+      # covered the moment they land; every target runs even if an earlier
+      # one finds a crash, and the job fails if any did.
+      - run: |
+          failed=0
+          for target in $(cargo +nightly fuzz list); do
+            cargo +nightly fuzz run "$target" -- -max_total_time=600 || failed=1
+          done
+          exit "$failed"
         working-directory: fuzz
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: fuzz-artifacts-${{ matrix.target }}
-          path: fuzz/artifacts/${{ matrix.target }}/
+          name: fuzz-artifacts
+          path: fuzz/artifacts/
           if-no-files-found: ignore

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,0 +1,36 @@
+name: fuzz-nightly
+
+# random-search fuzzing, separated from per-push CI on purpose: a red run
+# here means libFuzzer found a real input (the crash artifact is uploaded),
+# not that a push broke the build. while known crashers are open this will
+# fail by design; that is the job doing its work.
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fuzz:
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [compile, diff_regex, match_invariants]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz
+      - run: cargo install cargo-fuzz --locked
+      - run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=600
+        working-directory: fuzz
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: fuzz/artifacts/${{ matrix.target }}/
+          if-no-files-found: ignore


### PR DESCRIPTION



The repo currently has no CI, so the test suite and the fuzz targets only run
when someone remembers to run them locally. Two of the recent findings shipped
exactly that way (reachable `debug_assert` panics that any debug-assertions
test run fails loudly on). This adds two workflows, verified end to end on my
fork before opening:

## ci.yml, on every push and PR

- **test**, on ubuntu (AVX2) and macos-latest (arm64, so the NEON SIMD paths
  finally run somewhere automatic): `cargo test --workspace` with the dev
  profile's debug assertions on. Green on current main, both platforms,
  under a minute each with warm caches.
- **clippy**: `cargo clippy --workspace --all-targets`, warnings advisory
  (no `-D warnings`), deny-by-default correctness lints enforced. Currently
  red on main from one always-true comparison in `resharp-algebra`
  (`max <= u32::MAX` at lib.rs:1845); #23 removes it, and with
  that one-liner applied the job is green.
- **fuzz-replay**: builds all fuzz targets on nightly and replays only the
  committed seed corpus (`-runs=0`, no random search), so the job is
  deterministic: it catches target build rot and seed regressions, and stays
  green while known crashers are open. Each future bugfix can commit its
  reproducer as a `seed-*` file to grow this into a regression gate. Targets
  are enumerated with `cargo fuzz list` in both jobs, so targets added later
  are covered without touching the workflows.

## fuzz-nightly.yml, scheduled plus manual dispatch

Ten minutes of real random-search fuzzing per target, in parallel, uploading
crash artifacts on failure. Separated from per-push CI on purpose: a red run
here means libFuzzer found an input, not that a push broke the build. Fair
warning that while the open crashers from the recent fuzz reports are live,
this job will fail most nights (a 30-second random search already hits the
`lib.rs:1824` debug_assert), which is the job doing its work; if that noise
is unwanted until those are fixed, dropping the `schedule:` trigger and
keeping `workflow_dispatch:` makes it on-demand only.

## Verification

Run on the fork with this exact workflow: plain main gives test green on both
platforms, fuzz-replay green, clippy red on only the known lint
(https://github.com/Aquaticat/resharp/actions/runs/27380360883); main plus
the one-line guard fix gives all jobs green
(https://github.com/Aquaticat/resharp/actions/runs/27380383511).

