### PR TITLE
feat(engine): diag-gated scalar override, plus a SIMD-vs-scalar differential fuzz target

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -154,7 +154,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "resharp"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "resharp-algebra",
  "resharp-parser",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "resharp-algebra"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "rustc-hash",
 ]
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "resharp-parser"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "regex-syntax",
  "resharp-algebra",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 arbitrary = { version = "1", features = ["derive"] }
-resharp = { path = "../resharp-engine" }
+resharp = { path = "../resharp-engine", features = ["diag"] }
 # differential oracle for `diff_regex`; resharp already uses the regex crate as
 # a dev-dependency for its own comparison tests / benches.
 regex = "1"
@@ -33,6 +33,12 @@ path = "fuzz_targets/match_invariants.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "simd_diff"
+path = "fuzz_targets/simd_diff.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "diff_regex"

--- a/fuzz/fuzz_targets/simd_diff.rs
+++ b/fuzz/fuzz_targets/simd_diff.rs
@@ -1,0 +1,56 @@
+// differential: the SIMD-prefilter-accelerated find_all drivers vs the scalar
+// paths. prefix acceleration is decided while the Regex is built
+// (build_fwd_prefix returns None when has_simd() is false), so each side
+// compiles its own Regex with the override set accordingly; the two must then
+// agree exactly on every (pattern, haystack).
+//
+// this is the oracle that catches prefilter-driver soundness bugs the SIMD
+// intrinsic unit tests cannot see, e.g. `^$` over "\n\n" returning
+// [0:0, 2:2] from the accelerated driver while the scalar path returns the
+// correct [0:0, 1:1, 2:2].
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use resharp::{force_scalar, Regex};
+use resharp_fuzz::hex;
+
+fuzz_target!(|input: (&str, &[u8])| {
+    let (pattern, haystack) = input;
+
+    force_scalar(false);
+    let accel = match Regex::new(pattern) {
+        Ok(re) => re,
+        Err(_) => return,
+    };
+    let accel_result = accel.find_all(haystack);
+
+    force_scalar(true);
+    let scalar_re = Regex::new(pattern);
+    force_scalar(false);
+    let scalar = match scalar_re {
+        Ok(re) => re,
+        // both sides parsed the same pattern; compile must not depend on the
+        // override.
+        Err(e) => panic!("scalar compile failed after accel compile succeeded: {e:?} pattern={pattern:?}"),
+    };
+    let scalar_result = scalar.find_all(haystack);
+
+    match (accel_result, scalar_result) {
+        (Ok(a), Ok(s)) => assert_eq!(
+            a,
+            s,
+            "simd/scalar find_all diverge: accel={a:?} scalar={s:?} \
+             pattern={pattern:?} haystack_hex={}",
+            hex(haystack),
+        ),
+        (Err(_), Err(_)) => {}
+        (a, s) => panic!(
+            "simd/scalar error-status diverges: accel_ok={} scalar_ok={} \
+             pattern={pattern:?} haystack_hex={}",
+            a.is_ok(),
+            s.is_ok(),
+            hex(haystack),
+        ),
+    }
+});

--- a/fuzz/fuzz_targets/simd_diff.rs
+++ b/fuzz/fuzz_targets/simd_diff.rs
@@ -1,8 +1,10 @@
 // differential: the SIMD-prefilter-accelerated find_all drivers vs the scalar
-// paths. prefix acceleration is decided while the Regex is built
-// (build_fwd_prefix returns None when has_simd() is false), so each side
-// compiles its own Regex with the override set accordingly; the two must then
-// agree exactly on every (pattern, haystack).
+// paths. the override must cover the whole scalar side, not just
+// construction: prefix acceleration is decided while the Regex is built
+// (build_fwd_prefix returns None when has_simd() is false), and the lazy DFA
+// also consults has_simd() per newly built state DURING the scan
+// (try_build_skip_simd in ldfa.rs), so the guard holds force_scalar(true)
+// through find_all and resets on drop.
 //
 // this is the oracle that catches prefilter-driver soundness bugs the SIMD
 // intrinsic unit tests cannot see, e.g. `^$` over "\n\n" returning
@@ -15,26 +17,45 @@ use libfuzzer_sys::fuzz_target;
 use resharp::{force_scalar, Regex};
 use resharp_fuzz::hex;
 
+// scoped force_scalar: enabled on construction, reset on drop, so every exit
+// path (including assertion unwinds) restores the accelerated default.
+struct ForceScalar;
+
+impl ForceScalar {
+    fn new() -> Self {
+        force_scalar(true);
+        ForceScalar
+    }
+}
+
+impl Drop for ForceScalar {
+    fn drop(&mut self) {
+        force_scalar(false);
+    }
+}
+
 fuzz_target!(|input: (&str, &[u8])| {
     let (pattern, haystack) = input;
 
-    force_scalar(false);
     let accel = match Regex::new(pattern) {
         Ok(re) => re,
         Err(_) => return,
     };
     let accel_result = accel.find_all(haystack);
 
-    force_scalar(true);
-    let scalar_re = Regex::new(pattern);
-    force_scalar(false);
-    let scalar = match scalar_re {
-        Ok(re) => re,
-        // both sides parsed the same pattern; compile must not depend on the
-        // override.
-        Err(e) => panic!("scalar compile failed after accel compile succeeded: {e:?} pattern={pattern:?}"),
+    let scalar_result = {
+        let _scalar_scope = ForceScalar::new();
+        match Regex::new(pattern) {
+            // both construction and the scan run under the override; lazy DFA
+            // states built mid-scan must also take the scalar path.
+            Ok(re) => re.find_all(haystack),
+            // both sides parsed the same pattern; compile must not depend on
+            // the override.
+            Err(e) => panic!(
+                "scalar compile failed after accel compile succeeded: {e:?} pattern={pattern:?}"
+            ),
+        }
     };
-    let scalar_result = scalar.find_all(haystack);
 
     match (accel_result, scalar_result) {
         (Ok(a), Ok(s)) => assert_eq!(

--- a/fuzz/fuzz_targets/simd_diff.rs
+++ b/fuzz/fuzz_targets/simd_diff.rs
@@ -3,8 +3,8 @@
 // construction: prefix acceleration is decided while the Regex is built
 // (build_fwd_prefix returns None when has_simd() is false), and the lazy DFA
 // also consults has_simd() per newly built state DURING the scan
-// (try_build_skip_simd in ldfa.rs), so the guard holds force_scalar(true)
-// through find_all and resets on drop.
+// (try_build_skip_simd in ldfa.rs), so the force_scalar_scope() guard is held
+// through find_all and restores the previous state on drop.
 //
 // this is the oracle that catches prefilter-driver soundness bugs the SIMD
 // intrinsic unit tests cannot see, e.g. `^$` over "\n\n" returning
@@ -14,25 +14,8 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use resharp::{force_scalar, Regex};
+use resharp::{force_scalar_scope, Regex};
 use resharp_fuzz::hex;
-
-// scoped force_scalar: enabled on construction, reset on drop, so every exit
-// path (including assertion unwinds) restores the accelerated default.
-struct ForceScalar;
-
-impl ForceScalar {
-    fn new() -> Self {
-        force_scalar(true);
-        ForceScalar
-    }
-}
-
-impl Drop for ForceScalar {
-    fn drop(&mut self) {
-        force_scalar(false);
-    }
-}
 
 fuzz_target!(|input: (&str, &[u8])| {
     let (pattern, haystack) = input;
@@ -44,7 +27,9 @@ fuzz_target!(|input: (&str, &[u8])| {
     let accel_result = accel.find_all(haystack);
 
     let scalar_result = {
-        let _scalar_scope = ForceScalar::new();
+        // the guard restores the previous override state on every exit path,
+        // including assertion unwinds.
+        let _scalar_scope = force_scalar_scope();
         match Regex::new(pattern) {
             // both construction and the scan run under the override; lazy DFA
             // states built mid-scan must also take the scalar path.

--- a/resharp-engine/src/lib.rs
+++ b/resharp-engine/src/lib.rs
@@ -70,6 +70,8 @@ pub use prefix::calc_potential_start_prune;
 pub use prefix::calc_prefix_sets;
 #[cfg(feature = "diag")]
 pub use prefix::PrefixSets;
+#[cfg(feature = "diag")]
+pub use simd::force_scalar;
 pub(crate) use resharp_algebra::nulls::Nullability;
 pub(crate) use resharp_algebra::solver::TSetId;
 use resharp_algebra::Kind;

--- a/resharp-engine/src/lib.rs
+++ b/resharp-engine/src/lib.rs
@@ -71,7 +71,7 @@ pub use prefix::calc_prefix_sets;
 #[cfg(feature = "diag")]
 pub use prefix::PrefixSets;
 #[cfg(feature = "diag")]
-pub use simd::force_scalar;
+pub use simd::{force_scalar_scope, ForceScalarGuard};
 pub(crate) use resharp_algebra::nulls::Nullability;
 pub(crate) use resharp_algebra::solver::TSetId;
 use resharp_algebra::Kind;

--- a/resharp-engine/src/simd/mod.rs
+++ b/resharp-engine/src/simd/mod.rs
@@ -3,8 +3,27 @@ pub use resharp_algebra::solver::TSet;
 mod byte_freq;
 pub use byte_freq::BYTE_FREQ;
 
+// forces every has_simd() dispatch site to report no SIMD, so the scalar
+// fallbacks (and the non-prefilter find_all drivers, since build_fwd_prefix
+// bails when has_simd() is false) become reachable for differential testing.
+#[cfg(feature = "diag")]
+static FORCE_SCALAR: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+
+/// Force (or stop forcing) the scalar fallback at every SIMD dispatch site.
+/// Diagnostic hook for differential tests and fuzz targets; set it before
+/// building the `Regex` under test, since prefix acceleration is chosen at
+/// build time.
+#[cfg(feature = "diag")]
+pub fn force_scalar(force: bool) {
+    FORCE_SCALAR.store(force, core::sync::atomic::Ordering::Relaxed);
+}
+
 #[inline]
 pub fn has_simd() -> bool {
+    #[cfg(feature = "diag")]
+    if FORCE_SCALAR.load(core::sync::atomic::Ordering::Relaxed) {
+        return false;
+    }
     #[cfg(target_arch = "x86_64")]
     {
         std::arch::is_x86_feature_detected!("avx2")

--- a/resharp-engine/src/simd/mod.rs
+++ b/resharp-engine/src/simd/mod.rs
@@ -6,22 +6,44 @@ pub use byte_freq::BYTE_FREQ;
 // forces every has_simd() dispatch site to report no SIMD, so the scalar
 // fallbacks (and the non-prefilter find_all drivers, since build_fwd_prefix
 // bails when has_simd() is false) become reachable for differential testing.
+// SeqCst makes the override predictably visible across threads (its cost is
+// irrelevant for a diagnostic feature). needs byte atomics
+// (target_has_atomic = "8"); diag is a dev-host diagnostics feature, so
+// no-atomics targets are out of scope by construction.
 #[cfg(feature = "diag")]
 static FORCE_SCALAR: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 
-/// Force (or stop forcing) the scalar fallback at every SIMD dispatch site.
-/// Diagnostic hook for differential tests and fuzz targets; set it before
-/// building the `Regex` under test, since prefix acceleration is chosen at
-/// build time.
+/// Scoped scalar override: while the returned guard is alive, every SIMD
+/// dispatch site reports no SIMD. Diagnostic hook for differential tests and
+/// fuzz targets. Hold the guard across both `Regex` construction (prefix
+/// acceleration is chosen at build time) and the scan itself (the lazy DFA
+/// consults `has_simd()` per newly built state).
 #[cfg(feature = "diag")]
-pub fn force_scalar(force: bool) {
-    FORCE_SCALAR.store(force, core::sync::atomic::Ordering::Relaxed);
+pub fn force_scalar_scope() -> ForceScalarGuard {
+    ForceScalarGuard {
+        prev: FORCE_SCALAR.swap(true, core::sync::atomic::Ordering::SeqCst),
+    }
+}
+
+/// Guard returned by [`force_scalar_scope`]. Dropping it restores the
+/// previous override state, so scopes nest and panics/early returns cannot
+/// leave the override stuck on.
+#[cfg(feature = "diag")]
+pub struct ForceScalarGuard {
+    prev: bool,
+}
+
+#[cfg(feature = "diag")]
+impl Drop for ForceScalarGuard {
+    fn drop(&mut self) {
+        FORCE_SCALAR.store(self.prev, core::sync::atomic::Ordering::SeqCst);
+    }
 }
 
 #[inline]
 pub fn has_simd() -> bool {
     #[cfg(feature = "diag")]
-    if FORCE_SCALAR.load(core::sync::atomic::Ordering::Relaxed) {
+    if FORCE_SCALAR.load(core::sync::atomic::Ordering::SeqCst) {
         return false;
     }
     #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION



Adds the oracle that found the #20 bug: a runtime override that forces every
`has_simd()` dispatch site to take the scalar path, and a `simd_diff` fuzz
target asserting the accelerated and scalar engines return identical
`find_all` results. Standalone it runs via `cargo fuzz run simd_diff`; the
CI PR's fuzz jobs enumerate targets with `cargo fuzz list`, so once both
land, the nightly job covers this oracle automatically.

## Why an override is needed at all

`has_simd()` is hardcoded `true` on aarch64 (`simd/mod.rs:7`), and on x86-64 it
is a CPU-feature probe, so on any production host one of the two paths is
unreachable: the scalar fallback is dead code on ARM, and a
prefilter-driver-only bug (like #20's) can never be caught by comparing against
the scalar path in the field. The NEON/AVX2 intrinsic unit tests in `neon.rs`
are thorough but test candidate-byte location in isolation, not the driver's
use of the candidates, which is where #20 lived.

## What the override does

`force_scalar_scope()` returns an RAII guard; while it is alive, a static
atomic that `has_simd()` consults first reports no SIMD, and dropping the
guard restores the previous state (so scopes nest and panics cannot leave the
override stuck on). It is gated behind the existing `diag` feature, so
production builds compile to exactly the code that exists today, with no
atomic load.

Two subtleties the fuzz target encodes. Prefix acceleration is decided while
the `Regex` is built (`build_fwd_prefix` returns `None` when `has_simd()` is
false), so each differential side compiles its own `Regex`; disabling SIMD
therefore exercises both the scalar byte-search fallbacks and the
non-prefilter `find_all` drivers, which is exactly the comparison that
catches driver-level bugs. And the lazy DFA consults `has_simd()` again per
newly built state during the scan itself (`try_build_skip_simd`,
`ldfa.rs:458`), so the target holds the guard through `find_all` rather than
dropping it after construction.

## Verification

- On pre-#20 main, the differential deterministically reproduces the #20 bug:
  `^$` over `"\n\n"` gives `[0:0, 2:2]` accelerated (driver `FwdLbPrefix`) vs
  `[0:0, 1:1, 2:2]` scalar (driver `Dfa`).
- A two-minute `cargo fuzz run simd_diff` on pre-#20 main crashes on the live
  `debug_assert!(false, "found bug: this path should be eliminated")` at
  `lib.rs:1824`, independently rediscovering a known open finding; with the
  open soundness issues fixed the target is expected to run clean.
- `cargo test --workspace` is unaffected (the override defaults off and is
  feature-gated).

Also syncs `fuzz/Cargo.lock` with the 0.6.12 crate bump, which the version bump
commit on main missed.

