### PR TITLE
docs: document the cross-API agreement contract and the accepted superset

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,23 @@ Input is `&[u8]`. Matches are byte offsets `[start, end)`.
 pub struct Match { pub start: usize, pub end: usize }
 ```
 
+### How the APIs agree
+
+The matching APIs answer different questions about one language, so their
+answers are mutually constrained. These are the documented invariants (the
+`match_invariants` fuzz target asserts them):
+
+- `is_match` is true exactly when `find_all` is non-empty.
+- `find_anchored = Some` implies `is_match`; the returned span starts at 0 and
+  is the longest match there.
+- `find_all` returns leftmost-longest, non-overlapping matches in order.
+- `stream` returns leftmost-**shortest** matches (see Streaming below), so its
+  spans differ from `find_all` in general; `stream` is empty exactly when
+  `find_all` is empty, and when every match is zero-width the two enumerations
+  coincide (shortest and longest are the same span).
+- `hardened(true)` changes the scan algorithm and its complexity guarantee,
+  never the result: default and hardened return identical matches.
+
 ## RegexOptions
 
 ```rust

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,8 +22,10 @@ pub struct Match { pub start: usize, pub end: usize }
 ### How the APIs agree
 
 The matching APIs answer different questions about one language, so their
-answers are mutually constrained. These are the documented invariants (the
-`match_invariants` fuzz target asserts them):
+answers are mutually constrained. These are the documented invariants; the
+`match_invariants` fuzz target asserts the `find_all` ordering, the
+`is_match` agreement, and the anchored-at-0 part today, with the rest stated
+here as the contract the remaining checks (and fixes) converge on:
 
 - `is_match` is true exactly when `find_all` is non-empty.
 - `find_anchored = Some` implies `is_match`; the returned span starts at 0 and

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,14 +22,12 @@ pub struct Match { pub start: usize, pub end: usize }
 ### How the APIs agree
 
 The matching APIs answer different questions about one language, so their
-answers are mutually constrained. These are the documented invariants; the
-`match_invariants` fuzz target asserts the `find_all` ordering, the
-`is_match` agreement, and the anchored-at-0 part today, with the rest stated
-here as the contract the remaining checks (and fixes) converge on:
+answers are mutually constrained. The invariants below are the documented
+contract:
 
 - `is_match` is true exactly when `find_all` is non-empty.
-- `find_anchored = Some` implies `is_match`; the returned span starts at 0 and
-  is the longest match there.
+- If `find_anchored(...)` returns `Some(_)`, then `is_match` is true; the
+  returned span starts at 0 and is the longest match there.
 - `find_all` returns leftmost-longest, non-overlapping matches in order.
 - `stream` returns leftmost-**shortest** matches (see Streaming below), so its
   spans differ from `find_all` in general; `stream` is empty exactly when
@@ -37,6 +35,11 @@ here as the contract the remaining checks (and fixes) converge on:
   coincide (shortest and longest are the same span).
 - `hardened(true)` changes the scan algorithm and its complexity guarantee,
   never the result: default and hardened return identical matches.
+
+Today the `match_invariants` fuzz target asserts the `find_all` ordering, the
+`is_match` agreement, and the anchored-at-0 span. The remaining invariants are
+stated intent: known cross-API findings still violate some of them, and the
+fixes converge on the reading documented here.
 
 ## RegexOptions
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -5,8 +5,8 @@
 The crate deliberately accepts a superset of the patterns the RE#
 formalization (and the .NET `resharp-dotnet` engine) supports. The gatekeeper
 is `ensure_supported_rec` (`resharp-engine/src/lib.rs`): where the .NET engine
-rejects a construct class at compile, this crate accepts some of those shapes
-to unlock practical patterns, e.g.:
+rejects a whole class of constructs at compile time, this crate accepts some
+of those shapes to unlock practical patterns, e.g.:
 
 - lookarounds inside a union, when the union's branches are distinguishable
   (otherwise `UnsupportedPattern`);

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,5 +1,29 @@
 # Features
 
+## Patterns beyond the RE# fragment
+
+The crate deliberately accepts a superset of the patterns the RE#
+formalization (and the .NET `resharp-dotnet` engine) supports. The gatekeeper
+is `ensure_supported_rec` (`resharp-engine/src/lib.rs`): where the .NET engine
+rejects a construct class at compile, this crate accepts some of those shapes
+to unlock practical patterns, e.g.:
+
+- lookarounds inside a union, when the union's branches are distinguishable
+  (otherwise `UnsupportedPattern`);
+- a lookbehind-carrying union under an intersection, handled by eagerly
+  distributing `(A|B) & C` to `(A&C)|(B&C)`, which unlocks patterns like
+  `(^abc|def)&.*`.
+
+Two practical consequences:
+
+- A pattern compiling here is not evidence it is inside the formally verified
+  RE# fragment; portability to other RE# implementations is not implied.
+- The accepted-superset region is newer and has less formal backing than the
+  core fragment; recent fuzzing found most of its soundness issues exactly
+  there. If you need maximum confidence, staying inside the fragment (no
+  lookaround-in-union, no anchors under complement) is the conservative
+  choice.
+
 ## Hardened mode
 
 Guarantees **linear matching for all patterns and all match-collecting APIs** (`find_all`, etc.) in O(N·S), where N is input length and S is DFA states. The default engine is linear on the vast majority of patterns but can go quadratic on `find_all` when a pattern produces dense reverse-scan candidates. Hardened mode rules that out unconditionally.


### PR DESCRIPTION



Two documentation gaps that came out of the recent fuzz rounds, both
prose-only:

1. `docs/api.md` now states how the matching APIs constrain each other
   (`is_match` iff `find_all` non-empty; `find_anchored = Some` implies
   `is_match`; `stream` empty iff `find_all` empty, coinciding on purely
   zero-width result sets; hardened changes the algorithm and complexity
   guarantee, never the result). The `match_invariants` fuzz target asserts a
   subset of these today (ordering, `is_match` agreement, anchored-at-0); the
   rest are what the cross-API findings in #21 violate, so writing them down
   makes "which side of the disagreement is the bug" a documented answer
   instead of a judgment call per report.

2. `docs/features.md` now explains that the crate deliberately accepts a
   superset of the RE# formal fragment (`ensure_supported_rec` accepts
   distinguishable lookaround-in-union, and unlocks `(A|B) & C` shapes by
   eager distribution), and what that implies: compiling here does not mean a
   pattern is in the verified fragment, and the superset region is where most
   of the recent soundness findings live, so fragment-only patterns remain the
   conservative choice. This is currently only discoverable by reading
   `ensure_supported_rec` and a code comment.

If any of the stated invariants is not actually intended (for example, if
`stream`'s zero-width behavior is meant to differ from `find_all`), that is
worth knowing before the #21 fixes land, since the fixes will otherwise
converge on the documented reading.
