### PR TITLE
Make the RegexBuilder derive from Clone

### DIFF
--- a/resharp-algebra/src/lib.rs
+++ b/resharp-algebra/src/lib.rs
@@ -193,6 +193,7 @@ struct Metadata {
     nulls: NullsId,
 }
 
+#[derive(Clone)]
 struct MetadataBuilder {
     num_created: u32,
     solver: Solver,
@@ -323,6 +324,7 @@ impl BuilderFlags {
     pub(crate) const SUBSUME: BuilderFlags = BuilderFlags(1);
 }
 
+#[derive(Clone)]
 pub struct RegexBuilder {
     mb: MetadataBuilder,
     temp_vec: Vec<NodeId>,

--- a/resharp-algebra/src/nulls.rs
+++ b/resharp-algebra/src/nulls.rs
@@ -96,7 +96,7 @@ impl NullRun {
 type Nulls = Vec<NullRun>;
 
 /// Append-only arena of `RunList` nodes, addressed by index instead of `Rc`.
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct RunArena {
     nodes: Vec<(NullRun, Option<u32>)>,
 }
@@ -677,19 +677,20 @@ pub fn collect_nulls(
 }
 
 #[repr(u8)]
-#[derive(Hash, PartialEq, Eq)]
+#[derive(Hash, PartialEq, Eq, Clone)]
 enum Operation {
     Or,
     Inter,
 }
 
-#[derive(Hash, PartialEq, Eq)]
+#[derive(Hash, PartialEq, Eq, Clone)]
 struct Key {
     op: Operation,
     left: NullsId,
     right: NullsId,
 }
 
+#[derive(Clone)]
 pub struct NullsBuilder {
     cache: FxHashMap<Nulls, NullsId>,
     created: FxHashMap<Key, NullsId>,

--- a/resharp-algebra/src/solver.rs
+++ b/resharp-algebra/src/solver.rs
@@ -124,6 +124,7 @@ impl TSetId {
 use rustc_hash::FxHashMap;
 use std::collections::BTreeSet;
 
+#[derive(Clone)]
 pub struct Solver {
     cache: FxHashMap<TSet, TSetId>,
     pub array: Vec<TSet>,


### PR DESCRIPTION
The RegexBuilder did not derive from Clone, this change fixes that and makes RegexBuilder-caching easier.